### PR TITLE
tickets/DM-34032: Added the Enabled tests.

### DIFF
--- a/Enabled/Enabled.robot
+++ b/Enabled/Enabled.robot
@@ -1,0 +1,64 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify ATCS CSCs Enabled
+    [Tags]    atcs
+    FOR    ${csc}    IN    @{ATCS}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify AT_Light_Cal CSCs Enabled
+    [Tags]    at_light_cal    skipped
+    FOR    ${csc}    IN    @{AT_Light_Cal}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify ComCam CSCs Enabled
+    [Tags]    comcam
+    FOR    ${csc}    IN    @{ComCam}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify EAS CSCs Enabled
+    [Tags]    eas
+    FOR    ${csc}    IN    @{EAS}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify EAS_AE CSCs Enabled
+    [Tags]    eas_ae
+    FOR    ${csc}    IN    @{EAS_AE}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify LATISS CSCs Enabled
+    [Tags]    latiss
+    FOR    ${csc}    IN    @{LATISS}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify MTCS CSCs Enabled
+    [Tags]    mtcs
+    FOR    ${csc}    IN    @{MTCS}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify ObsSys1 CSCs Enabled
+    [Tags]    obssys1
+    FOR    ${csc}    IN    @{ObsSys1}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END
+
+Verify ObsSys2 CSCs Enabled
+    [Tags]    obssys2
+    FOR    ${csc}    IN    @{ObsSys2}
+        Run Keyword and Continue on Failure    Verify Summary State    ${STATES}[enabled]    ${csc}
+    END

--- a/Enabled/Verify_ATCS_Enabled.robot
+++ b/Enabled/Verify_ATCS_Enabled.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify ATAOS Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATAOS
+
+Verify ATDome Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATDome
+
+Verify ATDomeTrajectory Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATDomeTrajectory
+
+Verify ATHexapod Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATHexapod
+
+Verify ATMCS Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATMCS
+
+Verify ATPneumatics Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATPneumatics
+
+Verify ATPtg Enabled
+    [Tags]    atcs
+    Verify Summary State    ${STATES}[enabled]    ATPtg

--- a/Enabled/Verify_AT_Light_Cal_Enabled.robot
+++ b/Enabled/Verify_AT_Light_Cal_Enabled.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled    skipped
+
+*** Variables ***
+
+*** Test Cases ***
+Verify ATMonochromator Enabled
+    [Tags]    at_light_cal
+    Log    ${STATES}[enabled]
+    Verify Summary State    ${STATES}[enabled]    ATMonochromator
+
+Verify FiberSpectrograph:3 Enabled
+    [Tags]    at_light_cal
+    Verify Summary State    ${STATES}[enabled]    FiberSpectrograph:3

--- a/Enabled/Verify_ComCam_Enabled.robot
+++ b/Enabled/Verify_ComCam_Enabled.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify CCArchiver Enabled
+    [Tags]    comcam
+    Verify Summary State    ${STATES}[enabled]    CCArchiver
+
+Verify CCCamera Enabled
+    [Tags]    comcam
+    Verify Summary State    ${STATES}[enabled]    CCCamera
+
+Verify CCHeaderService Enabled
+    [Tags]    comcam
+    Verify Summary State    ${STATES}[enabled]    CCHeaderService

--- a/Enabled/Verify_EAS_AE_Enabled.robot
+++ b/Enabled/Verify_EAS_AE_Enabled.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify DSM:1 Enabled
+    [Tags]    eas_ae
+    Verify Summary State    ${STATES}[enabled]    DSM:1
+
+Verify DSM:2 Enabled
+    [Tags]    eas_ae
+    Verify Summary State    ${STATES}[enabled]    DSM:2

--- a/Enabled/Verify_EAS_Enabled.robot
+++ b/Enabled/Verify_EAS_Enabled.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify DIMM:1 Enabled
+    [Tags]    eas
+    Verify Summary State    ${STATES}[enabled]    DIMM:1
+
+Verify DIMM:2 Enabled
+    [Tags]    eas
+    Verify Summary State    ${STATES}[enabled]    DIMM:2
+
+Verify WeatherStation:1 Enabled
+    [Tags]    eas
+    Verify Summary State    ${STATES}[enabled]    WeatherStation:1

--- a/Enabled/Verify_LATISS_Enabled.robot
+++ b/Enabled/Verify_LATISS_Enabled.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify ATArchiver Enabled
+    [Tags]    latiss
+    Verify Summary State    ${STATES}[enabled]    ATArchiver
+
+Verify ATCamera Enabled
+    [Tags]    latiss
+    Verify Summary State    ${STATES}[enabled]    ATCamera
+
+Verify ATHeaderService Enabled
+    [Tags]    latiss
+    Verify Summary State    ${STATES}[enabled]    ATHeaderService
+
+Verify ATSpectrograph Enabled
+    [Tags]    latiss
+    Verify Summary State    ${STATES}[enabled]    ATSpectrograph

--- a/Enabled/Verify_MTCS_Enabled.robot
+++ b/Enabled/Verify_MTCS_Enabled.robot
@@ -1,0 +1,50 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify MTMount Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTMount
+
+Verify MTPtg Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTPtg
+
+Verify MTDome Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTDome
+
+Verify MTDomeTrajectory Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTDomeTrajectory
+
+Verify MTAOS Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTAOS
+
+Verify MTHexapod:1 Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTHexapod:1
+
+Verify MTHexapod:2 Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTHexapod:2
+
+Verify MTRotator Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTRotator
+
+Verify MTM1M3 Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTM1M3
+
+Verify MTM2 Enabled
+    [Tags]    mtcs
+    Verify Summary State    ${STATES}[enabled]    MTM2

--- a/Enabled/Verify_ObsSys1_Enabled.robot
+++ b/Enabled/Verify_ObsSys1_Enabled.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify ScriptQueue:1 Enabled
+    [Tags]    obsys1
+    Verify Summary State    ${STATES}[enabled]    ScriptQueue:1
+
+Verify ScriptQueue:2 Enabled
+    [Tags]    obsys1
+    Verify Summary State    ${STATES}[enabled]    ScriptQueue:2
+
+Verify Watcher Enabled
+    [Tags]    obsys1
+    Verify Summary State    ${STATES}[enabled]    Watcher

--- a/Enabled/Verify_ObsSys2_Enabled.robot
+++ b/Enabled/Verify_ObsSys2_Enabled.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Library    QueryEfd
+Library    Collections
+Library    String
+Resource    ../Global_Vars.resource
+Resource    ../CSC_Lists.resource
+Force Tags    enabled
+
+*** Variables ***
+
+*** Test Cases ***
+Verify Scheduler:1 Enabled
+    [Tags]    obsys2
+    Verify Summary State    ${STATES}[enabled]    Scheduler:1
+
+Verify Scheduler:2 Enabled
+    [Tags]    obsys2
+    Verify Summary State    ${STATES}[enabled]    Scheduler:2
+
+Verify OCPS:1 Enabled
+    [Tags]    obsys2
+    Verify Summary State    ${STATES}[enabled]    OCPS:1
+
+Verify OCPS:2 Enabled
+    [Tags]    obsys2
+    Verify Summary State    ${STATES}[enabled]    OCPS:2

--- a/Test_Report_Enabled.list
+++ b/Test_Report_Enabled.list
@@ -1,0 +1,16 @@
+###  Test Suite list ###
+#  Change the title of the test results
+--name Enabled
+--output enabled
+--skiponfailure skipped
+
+# List of test suites
+Enabled/Verify_ATCS_Enabled.robot
+Enabled/Verify_AT_Light_Cal_Enabled.robot
+Enabled/Verify_ComCam_Enabled.robot
+Enabled/Verify_EAS_AE_Enabled.robot
+Enabled/Verify_EAS_Enabled.robot
+Enabled/Verify_LATISS_Enabled.robot
+Enabled/Verify_MTCS_Enabled.robot
+Enabled/Verify_ObsSys1_Enabled.robot
+Enabled/Verify_ObsSys2_Enabled.robot


### PR DESCRIPTION
Added tags to Enabled/Verify_Enabled.robot.

Added the Verify_AT_Light_Cal_Enabled.robot Verify_ComCam_Enabled.robot test suites.

Added the Enabled test reporting suites, Enabled/*, and test list, Test_Report_Enabled.list.

Renamed Enabled/Verify_Enabled.robot to Enabled/Enabled.robot. This is prototype for a different test structure.