### PR TITLE
tickets/dm36922: Post Cycle28 updates

### DIFF
--- a/AuxTel/NightOps/Verify_CWFS_Align.robot
+++ b/AuxTel/NightOps/Verify_CWFS_Align.robot
@@ -15,7 +15,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]
+    [Tags]    runtime
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATAOS Corrections Enabled

--- a/AuxTel/NightOps/Verify_LATISS_Acq_Take_Sequence.robot
+++ b/AuxTel/NightOps/Verify_LATISS_Acq_Take_Sequence.robot
@@ -17,7 +17,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36476
+    [Tags]    runtime    DM-36476
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATAOS Corrections Enabled

--- a/AuxTel/Verify_AT_Image_Taking_Verification.robot
+++ b/AuxTel/Verify_AT_Image_Taking_Verification.robot
@@ -15,7 +15,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36864
+    [Tags]    runtime    DM-36864
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATCamera Playlist Loaded

--- a/AuxTel/Verify_AT_Prepare_Flat.robot
+++ b/AuxTel/Verify_AT_Prepare_Flat.robot
@@ -19,7 +19,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36956
+    [Tags]    runtime    DM-36956
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATDome AzimuthInPosition

--- a/AuxTel/Verify_AT_Prepare_Onsky.robot
+++ b/AuxTel/Verify_AT_Prepare_Onsky.robot
@@ -19,7 +19,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36474
+    [Tags]    runtime    DM-36474
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATDome AzimuthInPosition

--- a/AuxTel/Verify_AT_Shutdown.robot
+++ b/AuxTel/Verify_AT_Shutdown.robot
@@ -18,7 +18,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36978
+    [Tags]    runtime    DM-36978
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATAOS Corrections Disabled

--- a/AuxTel/Verify_AT_Stop.robot
+++ b/AuxTel/Verify_AT_Stop.robot
@@ -19,7 +19,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36475
+    [Tags]    runtime    DM-36475
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify ATDome logevent_azimuthInPosition

--- a/ComCam/Verify_ComCam_Calibrations.robot
+++ b/ComCam/Verify_ComCam_Calibrations.robot
@@ -16,7 +16,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36476
+    [Tags]    runtime    DM-36476
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify CCCamera Playlist Loaded

--- a/ComCam/Verify_ComCam_Image_Taking_Verification.robot
+++ b/ComCam/Verify_ComCam_Image_Taking_Verification.robot
@@ -15,7 +15,7 @@ Get Script Metadata
     Common_Keywords.Get Script Metadata
 
 Verify Runtime
-    [Tags]    DM-36864
+    [Tags]    runtime    DM-36864
     Verify Script Runtime    ${script_start}    ${script_end}
 
 Verify CCCamera Playlist Loaded
@@ -46,7 +46,7 @@ Verify CCCamera Image Sequence
 Verify CCOODS ImageInOODS
     [Tags]
     ${dataframe}=    Get Recent Samples    CCOODS    logevent_imageInOODS    ["camera", "description", "obsid",]    ${num_images}    None
-    Should Be Equal As Strings    ${dataframe.camera.values}[${0}]    LATISS
+    Should Be Equal As Strings    ${dataframe.camera.values}[${0}]    LSSTComCam
     Should Be Equal As Strings    ${dataframe.description.values}[${0}]    file ingested
     Should Be Equal As Strings    ${dataframe.obsid.values}[${0}]    ${image_names}[0][${0}]
 

--- a/Disabled/Verify_ObsSys1_Disabled.robot
+++ b/Disabled/Verify_ObsSys1_Disabled.robot
@@ -12,7 +12,7 @@ ${time_window}    10
 *** Test Cases ***
 Verify Authorize Disabled
     [Tags]    disabled
-    Verify Summary State    ${STATES}[disabled]    Authorize    True
+    Verify Summary State    ${STATES}[disabled]    Authorize    auto_enable=True
 
 Verify Authorize ConfigurationApplied Event
     [Tags]    config_applied
@@ -24,7 +24,7 @@ Verify Authorize ConfigurationApplied timing
 
 Verify ScriptQueue:1 Disabled
     [Tags]    disabled
-    Verify Summary State    ${STATES}[disabled]    ScriptQueue:1    True
+    Verify Summary State    ${STATES}[disabled]    ScriptQueue:1    auto_enable=True
 
 Verify ScriptQueue:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -32,7 +32,7 @@ Verify ScriptQueue:1 ConfigurationApplied Event
 
 Verify ScriptQueue:2 Disabled
     [Tags]    disabled
-    Verify Summary State    ${STATES}[disabled]    ScriptQueue:2    True
+    Verify Summary State    ${STATES}[disabled]    ScriptQueue:2    auto_enable=True
 
 Verify ScriptQueue:2 ConfigurationApplied Event
     [Tags]    config_applied
@@ -40,7 +40,7 @@ Verify ScriptQueue:2 ConfigurationApplied Event
 
 Verify Watcher Disabled
     [Tags]    disabled
-    Verify Summary State    ${STATES}[disabled]    Watcher    True
+    Verify Summary State    ${STATES}[disabled]    Watcher    auto_enable=True
 
 Verify Watcher ConfigurationApplied Event
     [Tags]    config_applied

--- a/QueryEfd.py
+++ b/QueryEfd.py
@@ -257,8 +257,10 @@ class QueryEfd:
         # Log the full dataframe.
         print(f"*TRACE*dataframe:\n{full_df}")
         # Which row of the DataFrame is needed depends on the expected_state.
-        if auto_enable and csc != "MTAirCompressor":
+        if auto_enable and csc != "MTAirCompressor" and expected_state != 1:
             row_index = 2
+        elif auto_enable and csc != "MTAirCompressor" and expected_state == 1:
+            row_index = 1
         elif auto_enable and csc == "MTAirCompressor" and expected_state == 5:
             row_index = 1
         else:
@@ -272,7 +274,7 @@ class QueryEfd:
         expected_state_str = state_enums.as_state(int(expected_state)).name
         actual_state_str = state_enums.as_state(int(ss_df.summaryState[0])).name
         event_sent_time = ss_df.private_sndStamp[0].strftime(self.time_format)
-        # Pass if CSC is in expected_state. Raise AssertionError is not.
+        # Pass if CSC is in expected_state and raise AssertionError if not.
         if str(actual_state_str) == str(expected_state_str):
             print(f"{csc_str} in {expected_state_str} State")
             print(f"Time of Summary State: {event_sent_time}")

--- a/Shutdown/Verify_MTCS_Shutdown.robot
+++ b/Shutdown/Verify_MTCS_Shutdown.robot
@@ -19,13 +19,13 @@ Verify MTAlignment Shutdown
 
 Verify MTAirCompressor:1 Shutdown
     [Tags]    mtcs
-    Verify Shutdown Process    MTAirCompressor:1
-    Verify Time Delta    MTAirCompressor:1    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Shutdown Process    MTAirCompressor    1
+    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    ${time_window}    index=1
 
 Verify MTAirCompressor:2 Shutdown
     [Tags]    mtcs
-    Verify Shutdown Process    MTAirCompressor:2
-    Verify Time Delta    MTAirCompressor:2    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Shutdown Process    MTAirCompressor    2
+    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    ${time_window}    index=2
 
 Verify MTMount Shutdown
     [Tags]    mtcs

--- a/Vars.txt
+++ b/Vars.txt
@@ -16,5 +16,5 @@
 --reportbackground #61C4CD:#61C4CD
 
 #  Redefine default variables
---variable XMLVersion:13.0.0
---variable SALVersion:7.0.0
+--variable XMLVersion:14.0.0
+--variable SALVersion:7.2.0


### PR DESCRIPTION
Bumped the XML and SAL versions in Vars.txt.

Made explicit the auto_enable=True positional argument in Disabled/Verify_ObsSys1_Disabled.robot.

Corrected the indexed MTAirCompressor reference in Shutdown/Verify_MTCS_Shutdown.robot.

Needed one more logical path in verify_summary_state keyword in QueryEfd.py.