### PR TITLE
Tickets/dm39091: Use SQ ProcessStates instead of ScriptStates enums

### DIFF
--- a/AuxTel/Verify_AT_Prepare_Flat.robot
+++ b/AuxTel/Verify_AT_Prepare_Flat.robot
@@ -30,7 +30,7 @@ Verify ATDome AzimuthInPosition
     Should Be True    ${delta} > 0
     Verify Topic Attribute    ATDome    logevent_azimuthInPosition    ["inPosition",]    ["True",]
 
-Verify ATDome azimuthState
+Verify ATDome azimuthState is NotInMotion
     [Tags]
     ${dataframe}=    Get Recent Samples    ATDome    logevent_azimuthState    ["homed", "state",]    1    None
     Should Be Equal As Integers    ${dataframe.state.values}[0]    1    #NotInMotion
@@ -42,15 +42,31 @@ Verify ATDome Position
     Should Be Equal As Integers    ${dataframe.dropoutDoorOpeningPercentage.values}[0]    0
     Should Be Equal As Integers    ${dataframe.mainDoorOpeningPercentage.values}[0]    0
 
-Verify ATDome mainDoorState
+Verify ATDome mainDoorState is Closed
     [Tags]
     ${dataframe}=    Get Recent Samples    ATDome    logevent_mainDoorState    ["*",]    1    None
     Should Be Equal As Integers    ${dataframe.state.values}[0]    1    #Closed
 
-Verify ATDome dropoutDoorState
+Verify ATDome dropoutDoorState is Closed
     [Tags]
     ${dataframe}=    Get Recent Samples    ATDome    logevent_dropoutDoorState    ["*",]    1    None
     Should Be Equal As Integers    ${dataframe.state.values}[0]    1    #Closed
+
+Verify ATDomeTrajectory followingMode is False
+    [Tags]
+    ${dataframe}=    Get Recent Samples    ATDomeTrajectory    logevent_followingMode    ["*",]    1    None
+    Should Not Be True    ${dataframe.enabled.values}[0]
+
+Verify ATHexapod inPosition is True
+    [Tags]
+    ${dataframe}=    Get Recent Samples    ATHexapod    logevent_inPosition    ["*",]    1    None
+    Should Be True    ${dataframe.inPosition.values}[0]
+
+Verify ATMCS allAxesInPosition
+    [Tags]
+    ${dataframe}=    Get Recent Samples    ATMCS    logevent_allAxesInPosition    ["*",]    2    None
+    Should Be True    ${dataframe.inPosition.values}[1]    #True when Mount reaches the flatfield position.
+    Should Not Be True    ${dataframe.inPosition.values}[0]    #Goes back to False a few seconds later, in preparation for the next move.
 
 Verify ATMCS Tracking Disabled
     [Tags]
@@ -61,17 +77,17 @@ Verify ATMCS Tracking Disabled
     ${dataframe}=    Get Recent Samples    ATMCS    logevent_elevationInPosition    ["*",]    1    None
     Should Not Be True    ${dataframe.inPosition.values}[0]
 
-Verify ATMCS m3State
+Verify ATMCS m3State is NASMYTH2
     [Tags]
     ${dataframe}=    Get Recent Samples    ATMCS    logevent_m3State    ["*",]    1    None
     Should Be Equal As Integers    ${dataframe.state.values}[0]    7    #NASMYTH2
     
-Verify ATPneumatics m1CoverState
+Verify ATPneumatics m1CoverState is Opened
     [Tags]
     ${dataframe}=    Get Recent Samples    ATPneumatics    logevent_m1CoverState    ["*",]    1    None
     Should Be Equal As Integers    ${dataframe.state.values}[0]    7    #Opened
 
-Verify ATPneumatics m1CoverLimitSwitches Opened
+Verify ATPneumatics m1CoverLimitSwitches are Opened
     [Tags]
     ${dataframe}=    Get Recent Samples    ATPneumatics    logevent_m1CoverLimitSwitches    ["*",]    1    None
     Should Be True    ${dataframe.cover1OpenedActive.values}[0]
@@ -83,12 +99,17 @@ Verify ATPneumatics m1CoverLimitSwitches Opened
     Should Not Be True    ${dataframe.cover3ClosedActive.values}[0]
     Should Not Be True    ${dataframe.cover4ClosedActive.values}[0]
 
-Verify ATPneumatics m1State
+Verify ATPneumatics mainValveState is Opened
+    [Tags]
+    ${dataframe}=    Get Recent Samples    ATPneumatics    logevent_mainValveState    ["*",]    1    None
+    Should Be Equal As Integers    ${dataframe.state.values}[0]    6    #OPENED - MainValveState
+
+Verify ATPneumatics m1State is Opened
     [Tags]
     ${dataframe}=    Get Recent Samples    ATPneumatics    logevent_m1State    ["*",]    1    None
     Should Be Equal As Integers    ${dataframe.state.values}[0]    6    #OPENED - AirValveState
 
-Verify ATPneumatics m2State
+Verify ATPneumatics m2State is Closed
     [Tags]
     ${dataframe}=    Get Recent Samples    ATPneumatics    logevent_m2State    ["*",]    1    None
-    Should Be Equal As Integers    ${dataframe.state.values}[0]    6    #OPENED - AirValveState
+    Should Be Equal As Integers    ${dataframe.state.values}[0]    7    #CLOSED - AirValveState

--- a/Common_Keywords.resource
+++ b/Common_Keywords.resource
@@ -25,7 +25,7 @@ Execute Integration Test
 Verify Scripts Completed Successfully
     [Documentation]    The keyword requires two arguments, the list of `script_indexes` for each script, 
     ...    and the list of associated `script_states` for each script. It then iterates over the lists to 
-    ...    retrieve script metadata and verify each script completed as DONE (enum value 8).  
+    ...    retrieve script metadata and verify each script completed as DONE (enum value 4).  
     [Arguments]    ${script_indexes}    ${script_states}
     ${num_scripts}=    Get Length    ${script_indexes}
     ${num_states}=    Get Length    ${script_states}
@@ -33,8 +33,8 @@ Verify Scripts Completed Successfully
     # There is a ~0.03s delay before the very last event is sent; it populates the timestampProcessEnd field. 
     # So wait for 'Get Script Metadata' to succeed.
     FOR    ${i}    IN RANGE    ${num_scripts}
-        Wait Until Keyword Succeeds    5x    1 sec    Get Script Metadata    ${script_indexes}[${i}]
-        Should Be Equal As Integers    ${script_states}[${i}]    8    values=True    msg=Script index ${script_indexes}[${i}]
+        Get Script Metadata    ${script_indexes}[${i}]
+        Should Be Equal As Integers    ${script_states}[${i}]    4    values=True    msg=Script index ${script_indexes}[${i}]
     END
 
 Get Script Metadata


### PR DESCRIPTION
* Also updated AuxTel/Verify_AT_Prepare_Flat.robot, as that was the report suite used to test out the enum switch.