### PR TITLE
Tickets/dm41264: Handle Pandas deprecation warning

### DIFF
--- a/AuxTel/DaytimeCheck/Verify_LATISS_Checkout.robot
+++ b/AuxTel/DaytimeCheck/Verify_LATISS_Checkout.robot
@@ -7,7 +7,6 @@ Force Tags    latiss_checkout
 Suite Setup    Check If Failed
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist

--- a/AuxTel/DaytimeCheck/Verify_Slew_and_Take_Image_Checkout.robot
+++ b/AuxTel/DaytimeCheck/Verify_Slew_and_Take_Image_Checkout.robot
@@ -7,7 +7,6 @@ Force Tags    slew_take_image_checkout
 Suite Setup    Check If Failed
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist

--- a/AuxTel/DaytimeCheck/Verify_Telescope_Dome_Checkout.robot
+++ b/AuxTel/DaytimeCheck/Verify_Telescope_Dome_Checkout.robot
@@ -7,7 +7,6 @@ Force Tags    at_telescope_dome_checkout
 Suite Setup    Check If Failed
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Execute AuxTel Telescope and Dome Checkout Test

--- a/AuxTel/NightOps/Verify_LATISS_Acq_Take_Sequence.robot
+++ b/AuxTel/NightOps/Verify_LATISS_Acq_Take_Sequence.robot
@@ -7,7 +7,6 @@ Force Tags    at_night_ops    acq_take_seq
 Suite Setup    Run Keywords    Check If Failed    AND    Set Variables    ${playlist}
 
 *** Variables ***
-${time_window}    10
 ${playlist}    replace_me
 
 *** Test Cases ***
@@ -51,7 +50,7 @@ Verify ATPtg Target
         ${topic_sent}=    Convert Date    ${output}    result_format=datetime
         ${delta}=    Subtract Date From Date    ${topic_sent}    ${script_start}
         Should Be True    ${delta} > 0
-        Verify Time Delta    ATPtg    command_raDecTarget    logevent_currentTarget    ${time_window}
+        Verify Time Delta    ATPtg    command_raDecTarget    logevent_currentTarget
         ${cmd_dataframe}=    Get Recent Samples    ATPtg    command_raDecTarget    ["targetName", "ra", "declination",]    1    None
         Should Be Equal    ${cmd_dataframe.targetName.values}[0]    HD164461
         Should Be Equal    ${cmd_dataframe.ra.values.round(6)}[0]    ${18.913095}
@@ -107,8 +106,8 @@ Verify ATSpectrograph ChangeFilter
     ${topic_sent}=    Convert Date    ${output}    result_format=datetime
     ${delta}=    Subtract Date From Date    ${topic_sent}    ${script_start}
     Should Be True    ${delta} > 0
-    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_filterInPosition    ${time_window}
-    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_reportedFilterPosition    ${time_window}
+    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_filterInPosition
+    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_reportedFilterPosition
     Verify Topic Attribute    ATSpectrograph    logevent_filterInPosition    ["inPosition",]    [True,]
 
 Verify ATSpectrograph Filter
@@ -122,8 +121,8 @@ Verify ATSpectrograph ChangeDisperser
     ${topic_sent}=    Convert Date    ${output}    result_format=datetime
     ${delta}=    Subtract Date From Date    ${topic_sent}    ${script_start}
     Should Be True    ${delta} > 0
-    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_disperserInPosition    ${time_window}
-    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_reportedDisperserPosition    ${time_window}
+    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_disperserInPosition
+    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_reportedDisperserPosition
     Verify Topic Attribute    ATSpectrograph    logevent_disperserInPosition    ["inPosition",]    [True,]
 
 Verify ATSpectrograph Disperser

--- a/AuxTel/NightOps/Verify_WEP_Align.robot
+++ b/AuxTel/NightOps/Verify_WEP_Align.robot
@@ -7,7 +7,6 @@ Force Tags    at_night_ops    wep_align
 Suite Setup    Check If Failed
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Execute AuxTel Reset Offsets
@@ -18,7 +17,7 @@ Execute AuxTel Reset Offsets
 Verify ATAOS Corrections Enabled
     [Documentation]    Corrections should already be enabled, ensure nothing was changed prior to running this script.
     [Tags]
-    Verify Time Delta    ATAOS    command_enableCorrection    logevent_correctionEnabled    ${time_window}
+    Verify Time Delta    ATAOS    command_enableCorrection    logevent_correctionEnabled
     ${dataframe}=    Get Recent Samples    ATAOS    logevent_correctionEnabled    ["*",]    1    None
     Should Be True    $dataframe.atspectrograph.values
     Should Be True    $dataframe.hexapod.values
@@ -47,7 +46,7 @@ Verify ATPtg Target
     ${topic_sent}=    Convert Date    ${output}    result_format=datetime
     ${delta}=    Subtract Date From Date    ${topic_sent}    ${script_start}
     Should Be True    ${delta} > 0
-    Verify Time Delta    ATPtg    command_raDecTarget    logevent_currentTarget    ${time_window}
+    Verify Time Delta    ATPtg    command_raDecTarget    logevent_currentTarget
     Verify Topic Attribute    ATPtg    command_raDecTarget    ["targetName"]    ["HD164461"]
     Verify Topic Attribute    ATPtg    command_raDecTarget    ["ra"]    [${18.913095}]
     Verify Topic Attribute    ATPtg    command_raDecTarget    ["declination"]    [${-87.605843}]
@@ -114,8 +113,8 @@ Verify ATSpectrograph ChangeFilter
     ${topic_sent}=    Convert Date    ${output}    result_format=datetime
     ${delta}=    Subtract Date From Date    ${topic_sent}    ${script_start}
     Should Be True    ${delta} > 0
-    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_filterInPosition    ${time_window}
-    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_reportedFilterPosition    ${time_window}
+    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_filterInPosition
+    Verify Time Delta    ATSpectrograph    command_changeFilter    logevent_reportedFilterPosition
     Verify Topic Attribute    ATSpectrograph    logevent_filterInPosition    ["inPosition",]    [True,]
 
 Verify ATSpectrograph Filter
@@ -129,8 +128,8 @@ Verify ATSpectrograph ChangeDisperer
     ${topic_sent}=    Convert Date    ${output}    result_format=datetime
     ${delta}=    Subtract Date From Date    ${topic_sent}    ${script_start}
     Should Be True    ${delta} > 0
-    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_disperserInPosition    ${time_window}
-    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_reportedDisperserPosition    ${time_window}
+    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_disperserInPosition
+    Verify Time Delta    ATSpectrograph    command_changeDisperser    logevent_reportedDisperserPosition
     Verify Topic Attribute    ATSpectrograph    logevent_disperserInPosition    ["inPosition",]    [True,]
 
 Verify ATSpectrograph Disperser

--- a/AuxTel/Verify_AT_Flat_Calibrations.robot
+++ b/AuxTel/Verify_AT_Flat_Calibrations.robot
@@ -7,7 +7,6 @@ Force Tags    at_calibrations
 Suite Setup    Run Keywords    Check If Failed    AND    Set Variables
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist
@@ -42,7 +41,7 @@ Verify ATPtg Tracking is Off
     [Tags]
     ${evt_df}=    Get Recent Samples    ATPtg    logevent_trackPosting    ["status"]    1    None
     Should Not Be True    ${evt_df.status.values}[0]
-    Verify Time Delta    ATPtg    command_stopTracking    logevent_trackPosting    ${time_window}    
+    Verify Time Delta    ATPtg    command_stopTracking    logevent_trackPosting    
 
 Verify ATSpectrograph Filter
     [Tags]    DM-35582

--- a/AuxTel/Verify_AT_Image_Taking_Verification.robot
+++ b/AuxTel/Verify_AT_Image_Taking_Verification.robot
@@ -7,7 +7,6 @@ Force Tags    image_taking_verification
 Suite Setup    Check If Failed
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist

--- a/AuxTel/Verify_AT_PTC_Calibrations.robot
+++ b/AuxTel/Verify_AT_PTC_Calibrations.robot
@@ -7,7 +7,6 @@ Force Tags    at_calibrations
 Suite Setup    Run Keywords    Check If Failed    AND    Set Variables
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist
@@ -40,7 +39,7 @@ Verify ATPtg Tracking is Off
     [Tags]
     ${evt_df}=    Get Recent Samples    ATPtg    logevent_trackPosting    ["status"]    1    None
     Should Not Be True    ${evt_df.status.values}[0]
-    Verify Time Delta    ATPtg    command_stopTracking    logevent_trackPosting    ${time_window}    
+    Verify Time Delta    ATPtg    command_stopTracking    logevent_trackPosting    
 
 Verify ATSpectrograph Filter
     [Tags]    DM-35582

--- a/AuxTel/Verify_AT_Shutdown.robot
+++ b/AuxTel/Verify_AT_Shutdown.robot
@@ -10,7 +10,6 @@ Suite Setup    Check If Failed
 *** Variables ***
 @{atMountState}         state
 @{states_expected}      8
-${time_window}          10
 
 *** Test Cases ***
 Execute AuxTel Shutdown

--- a/AuxTel/Verify_Enable_ATCS.robot
+++ b/AuxTel/Verify_Enable_ATCS.robot
@@ -8,7 +8,6 @@ Suite Setup    Check If Failed
 
 *** Variables ***
 @{states_expected}      8
-${time_window}          10
 
 *** Test Cases ***
 Execute AuxTel Enable ATCS

--- a/BigCamera/Verify_BigCamera_Calibrations.robot
+++ b/BigCamera/Verify_BigCamera_Calibrations.robot
@@ -7,7 +7,6 @@ Force Tags    bigcamera    calibrations
 Suite Setup    Run Keywords    Check If Failed    AND    Set EFD Values    AND    Set Variables
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist
@@ -31,7 +30,7 @@ Verify MTPtg Target
     [Documentation]    Ensure the telescope is pointed at the correct target, in this case at the Az/El of the flat-field screen.
     ...    This command is sent prior to the start of the script.
     [Tags]    robot:continue-on-failure
-    Verify Time Delta    MTPtg    command_raDecTarget    logevent_currentTarget    ${time_window}
+    Verify Time Delta    MTPtg    command_raDecTarget    logevent_currentTarget
     ${cmd_dataframe}=    Get Recent Samples    MTPtg    command_raDecTarget    ["targetName", "ra", "declination",]    1    None
     Should Be Equal    ${cmd_dataframe.targetName.values}[0]    Flatfield position
     ${evt_dataframe}=    Get Recent Samples    MTPtg    logevent_currentTarget    ["targetName", "azDegs", "elDegs",]    1    None
@@ -43,7 +42,7 @@ Verify MTPtg Tracking is Off
     [Tags]
     ${evt_df}=    Get Recent Samples    MTPtg    logevent_trackPosting    ["status"]    1    None
     Should Not Be True    ${evt_df.status.values}[0]
-    Verify Time Delta    MTPtg    command_stopTracking    logevent_trackPosting    ${time_window}    
+    Verify Time Delta    MTPtg    command_stopTracking    logevent_trackPosting    
 
 Verify Camera Filter
     ${evt_df}=    Get Recent Samples    ${BigCamera}    logevent_startSetFilter    ["filterName", "filterType"]    1    None

--- a/BigCamera/Verify_BigCamera_Image_Taking_Verification.robot
+++ b/BigCamera/Verify_BigCamera_Image_Taking_Verification.robot
@@ -7,7 +7,6 @@ Force Tags    bigcamera    image_taking_verification
 Suite Setup    Run Keywords    Check If Failed    AND    Set EFD Values
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Load Camera Playlist

--- a/Disabled/Execute_Standby_Disabled.robot
+++ b/Disabled/Execute_Standby_Disabled.robot
@@ -5,7 +5,6 @@ Resource    ../Common_Keywords.resource
 Force Tags    disabled    execute
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Execute AuxTel Standby to Disabled 

--- a/Disabled/Verify_ATCS_Disabled.robot
+++ b/Disabled/Verify_ATCS_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    atcs
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 Verify ATAOS Disabled
     [Tags]    disabled
@@ -18,7 +15,7 @@ Verify ATAOS ConfigurationApplied Event
 
 Verify ATAOS ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATAOS    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATAOS    logevent_summaryState    logevent_configurationApplied
 
 Verify ATDome Disabled
     [Tags]    disabled
@@ -30,7 +27,7 @@ Verify ATDome ConfigurationApplied Event
 
 Verify ATDome ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATDome    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATDome    logevent_summaryState    logevent_configurationApplied
 
 Verify ATDomeTrajectory Disabled
     [Tags]    disabled
@@ -42,7 +39,7 @@ Verify ATDomeTrajectory ConfigurationApplied Event
 
 Verify ATDomeTrajectory ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    logevent_configurationApplied
 
 Verify ATHexapod Disabled
     [Tags]    disabled
@@ -54,7 +51,7 @@ Verify ATHexapod ConfigurationApplied Event
 
 Verify ATHexapod ConfigurationApplied Event timing 
     [Tags]    config_applied    timing
-    Verify Time Delta    ATHexapod    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATHexapod    logevent_summaryState    logevent_configurationApplied
 
 Verify ATMCS Disabled
     [Tags]    disabled

--- a/Disabled/Verify_AT_Light_Cal_Disabled.robot
+++ b/Disabled/Verify_AT_Light_Cal_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    at_light_cal    skipped
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 Verify ATMonochromator Disabled
     [Tags]    disabled
@@ -18,7 +15,7 @@ Verify ATMonochromator ConfigurationApplied Event
 
 Verify ATMonochromator ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_configurationApplied
 
 Verify FiberSpectrograph:3 Disabled
     [Tags]    disabled
@@ -30,4 +27,4 @@ Verify FiberSpectrograph:3 ConfigurationApplied Event
 
 Verify FiberSpectrograph:3 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    FiberSpectrograph    logevent_summaryState    logevent_configurationApplied    ${time_window}    3
+    Verify Time Delta    FiberSpectrograph    logevent_summaryState    logevent_configurationApplied    3

--- a/Disabled/Verify_BigCamera_Disabled.robot
+++ b/Disabled/Verify_BigCamera_Disabled.robot
@@ -5,9 +5,6 @@ Resource    ../Common_Keywords.resource
 Force Tags    disabled    bigcamera
 Suite Setup   Set EFD Values
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 #BigCamera
 Verify BigCamera Disabled
@@ -20,7 +17,7 @@ Verify BigCamera ConfigurationApplied Event
 
 Verify BigCamera ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_configurationApplied
 
 #OODS
 Verify OODS Disabled
@@ -51,4 +48,4 @@ Verify OCPS:2||3 ConfigurationApplied Event
 
 Verify OCPS:2||3 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=${OcpsIndex}
+    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationApplied    index=${OcpsIndex}

--- a/Disabled/Verify_EAS_AE_Disabled.robot
+++ b/Disabled/Verify_EAS_AE_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    eas_ae
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 Verify DSM:1 Disabled
     [Tags]    disabled

--- a/Disabled/Verify_EAS_Disabled.robot
+++ b/Disabled/Verify_EAS_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    eas
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 # DIMM:1
 Verify DIMM:1 Disabled
@@ -19,7 +16,7 @@ Verify DIMM:1 ConfigurationApplied Event
 
 Verify DIMM:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=1
+    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationApplied    index=1
 
 # DIMM:2
 Verify DIMM:2 Disabled
@@ -32,7 +29,7 @@ Verify DIMM:2 ConfigurationApplied Event
 
 Verify DIMM:2 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=2
+    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationApplied    index=2
 
 # ESS:1
 Verify ESS:1 Disabled
@@ -45,7 +42,7 @@ Verify ESS:1 ConfigurationApplied Event
 
 Verify ESS:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    1
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=1
 
 # ESS:101
 Verify ESS:101 Disabled
@@ -58,7 +55,7 @@ Verify ESS:101 ConfigurationApplied Event
 
 Verify ESS:101 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=101
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=101
 
 # ESS:102
 Verify ESS:102 Disabled
@@ -71,7 +68,7 @@ Verify ESS:102 ConfigurationApplied Event
 
 Verify ESS:102 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=102
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=102
 
 # ESS:103
 Verify ESS:103 Disabled
@@ -84,7 +81,7 @@ Verify ESS:103 ConfigurationApplied Event
 
 Verify ESS:103 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=103
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=103
 
 # ESS:104
 Verify ESS:104 Disabled
@@ -97,7 +94,7 @@ Verify ESS:104 ConfigurationApplied Event
 
 Verify ESS:104 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=104
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=104
 
 # ESS:105
 Verify ESS:105 Disabled
@@ -110,7 +107,7 @@ Verify ESS:105 ConfigurationApplied Event
     
 Verify ESS:105 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=105
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=105
 
 # ESS:106
 Verify ESS:106 Disabled
@@ -123,7 +120,7 @@ Verify ESS:106 ConfigurationApplied Event
     
 Verify ESS:106 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=106
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=106
 
 # ESS:201
 Verify ESS:201 Disabled
@@ -136,7 +133,7 @@ Verify ESS:201 ConfigurationApplied Event
 
 Verify ESS:201 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=201
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=201
 
 # ESS:202
 Verify ESS:202 Disabled
@@ -149,7 +146,7 @@ Verify ESS:202 ConfigurationApplied Event
 
 Verify ESS:202 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=202
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=202
 
 # ESS:203
 Verify ESS:203 Disabled
@@ -162,7 +159,7 @@ Verify ESS:203 ConfigurationApplied Event
 
 Verify ESS:203 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=203
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=203
 
 # ESS:204
 Verify ESS:204 Disabled
@@ -175,7 +172,7 @@ Verify ESS:204 ConfigurationApplied Event
 
 Verify ESS:204 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=204
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=204
 
 # ESS:301
 Verify ESS:301 Disabled
@@ -188,4 +185,4 @@ Verify ESS:301 ConfigurationApplied Event
 
 Verify ESS:301 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=301
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationApplied    index=301

--- a/Disabled/Verify_GC_Disabled.robot
+++ b/Disabled/Verify_GC_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    gc
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 Verify GenericCamera:1 Disabled
     [Tags]    disabled
@@ -18,7 +15,7 @@ Verify GenericCamera:1 ConfigurationApplied Event
 
 Verify GenericCamera:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    GenericCamera    logevent_summaryState    logevent_configurationApplied    ${time_window}    1
+    Verify Time Delta    GenericCamera    logevent_summaryState    logevent_configurationApplied    1
 
 Verify GCHeaderService:1 Disabled
     [Tags]    disabled

--- a/Disabled/Verify_LATISS_Disabled.robot
+++ b/Disabled/Verify_LATISS_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    latiss
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 #ATCamera
 Verify ATCamera Disabled
@@ -19,7 +16,7 @@ Verify ATCamera ConfigurationApplied Event
 
 Verify ATCamera ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATCamera    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATCamera    logevent_summaryState    logevent_configurationApplied
 
 #ATHeaderService
 Verify ATHeaderService Disabled
@@ -41,7 +38,7 @@ Verify OCPS:1 ConfigurationApplied Event
 
 Verify OCPS:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=1
+    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationApplied    index=1
 
 #ATOODS
 Verify ATOODS Disabled
@@ -63,4 +60,4 @@ Verify ATSpectrograph ConfigurationApplied Event
 
 Verify ATSpectrograph ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATSpectrograph    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    ATSpectrograph    logevent_summaryState    logevent_configurationApplied

--- a/Disabled/Verify_MTCS_Disabled.robot
+++ b/Disabled/Verify_MTCS_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    mtcs
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 #LaserTracker
 Verify LaserTracker:1 Disabled
@@ -19,7 +16,7 @@ Verify LaserTracker:1 ConfigurationApplied Event
 
 Verify LaserTracker:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    LaserTracker    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=1
+    Verify Time Delta    LaserTracker    logevent_summaryState    logevent_configurationApplied    index=1
 
 #MTAirCompressor:1
 Verify MTAirCompressor:1 Disabled
@@ -32,7 +29,7 @@ Verify MTAirCompressor:1 ConfigurationApplied Event
 
 Verify MTAirCompressor:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=1
+    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationApplied    index=1
 
 #MTAirCompressor:2
 Verify MTAirCompressor:2 Disabled
@@ -45,7 +42,7 @@ Verify MTAirCompressor:2 ConfigurationApplied Event
 
 Verify MTAirCompressor:2 ConfigurationApplied timing   
     [Tags]    config_applied    timing
-    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=1
+    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationApplied    index=1
 
 #MTMount
 Verify MTMount Disabled
@@ -58,7 +55,7 @@ Verify MTMount ConfigurationApplied Event
 
 Verify MTMount ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTMount    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTMount    logevent_summaryState    logevent_configurationApplied
 
 #MTPtg
 Verify MTPtg Disabled
@@ -80,7 +77,7 @@ Verify MTDome ConfigurationApplied Event
 
 Verify MTDome ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTDome    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTDome    logevent_summaryState    logevent_configurationApplied
 
 #MTDomeTrajectory
 Verify MTDomeTrajectory Disabled
@@ -93,7 +90,7 @@ Verify MTDomeTrajectory ConfigurationApplied Event
 
 Verify MTDomeTrajectory ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    logevent_configurationApplied
 
 #MTAOS
 Verify MTAOS Disabled
@@ -106,7 +103,7 @@ Verify MTAOS ConfigurationApplied Event
 
 Verify MTAOS ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTAOS    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTAOS    logevent_summaryState    logevent_configurationApplied
 
 #MTHexapod:1
 Verify MTHexapod:1 Disabled
@@ -119,7 +116,7 @@ Verify MTHexapod:1 ConfigurationApplied Event
 
 Verify MTHexapod:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=1
+    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationApplied    index=1
 
 #MTHexapod:2
 Verify MTHexapod:2 Disabled
@@ -132,7 +129,7 @@ Verify MTHexapod:2 ConfigurationApplied Event
 
 Verify MTHexapod:2 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=2
+    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationApplied    index=2
 
 #MTRotator
 Verify MTRotator Disabled
@@ -145,7 +142,7 @@ Verify MTRotator ConfigurationApplied Event
 
 Verify MTRotator ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTRotator    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTRotator    logevent_summaryState    logevent_configurationApplied
 
 #MTM1M3
 Verify MTM1M3 Disabled
@@ -158,7 +155,7 @@ Verify MTM1M3 ConfigurationApplied Event
 
 Verify MTM1M3 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTM1M3    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTM1M3    logevent_summaryState    logevent_configurationApplied
 
 #MTM2
 Verify MTM2 Disabled
@@ -171,4 +168,4 @@ Verify MTM2 ConfigurationApplied Event
 
 Verify MTM2 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTM2    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    MTM2    logevent_summaryState    logevent_configurationApplied

--- a/Disabled/Verify_ObsSys1_Disabled.robot
+++ b/Disabled/Verify_ObsSys1_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    obssys1
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 Verify Authorize Disabled
     [Tags]    disabled
@@ -18,7 +15,7 @@ Verify Authorize ConfigurationApplied Event
 
 Verify Authorize ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Authorize    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    Authorize    logevent_summaryState    logevent_configurationApplied
 
 Verify ScriptQueue:1 Disabled
     [Tags]    disabled
@@ -46,4 +43,4 @@ Verify Watcher ConfigurationApplied Event
 
 Verify Watcher ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Watcher    logevent_summaryState    logevent_configurationApplied    ${time_window}
+    Verify Time Delta    Watcher    logevent_summaryState    logevent_configurationApplied

--- a/Disabled/Verify_ObsSys2_Disabled.robot
+++ b/Disabled/Verify_ObsSys2_Disabled.robot
@@ -4,9 +4,6 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    obssys2
 
-*** Variables ***
-${time_window}    10
-
 *** Test Cases ***
 #Scheduler:1
 Verify Scheduler:1 Disabled
@@ -15,11 +12,11 @@ Verify Scheduler:1 Disabled
 
 Verify Scheduler:1 ConfigurationApplied Event
     [Tags]    config_applied
-    Verify ConfigurationApplied    Scheduler    1
+    Verify ConfigurationApplied    Scheduler    index=1
 
 Verify Scheduler:1 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationApplied    ${time_window}    1
+    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationApplied    index=1
 
 #Scheduler:2
 Verify Scheduler:2 Disabled
@@ -28,8 +25,8 @@ Verify Scheduler:2 Disabled
 
 Verify Scheduler:2 ConfigurationApplied Event
     [Tags]    config_applied
-    Verify ConfigurationApplied    Scheduler    2
+    Verify ConfigurationApplied    Scheduler    index=2
 
 Verify Scheduler:2 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationApplied    ${time_window}    index=2
+    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationApplied    index=2

--- a/Offline/Verify_Cameras_Offline.robot
+++ b/Offline/Verify_Cameras_Offline.robot
@@ -8,7 +8,6 @@ Suite Setup    Set EFD Values
 *** Variables ***
 ${offdet_topic}    logevent_offlineDetailedState
 @{offdet_fields}    "private_sndStamp"    "substate"
-${time_window}    600
 
 *** Test Cases ***
 #ATCamera
@@ -22,7 +21,7 @@ Verify ATCamera SoftwareVersions
 
 Verify ATCamera SoftwareVersions timing
     [Tags]    latiss    software_versions    timing
-    Verify Time Delta    ATCamera    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATCamera    logevent_summaryState    logevent_softwareVersions
 
 Verify ATCamera OfflineDetailedStates
     [Tags]    latiss    detailed_states
@@ -44,7 +43,7 @@ Verify ATCamera OfflineDetailedStates
 
 Verify ATCamera OfflineDetailedStates timing
     [Tags]    latiss    detailed_states    timing
-    Verify Time Delta    ATCamera    logevent_summaryState    ${offdet_topic}    ${time_window}
+    Verify Time Delta    ATCamera    logevent_summaryState    ${offdet_topic}
 
 #BigCamera
 Verify BigCamera Offline
@@ -57,7 +56,7 @@ Verify BigCamera SoftwareVersions
 
 Verify BigCamera SoftwareVersions timing
     [Tags]    bigcamera    software_versions    timing
-    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_softwareVersions
 
 Verify BigCamera OfflineDetailedStates
     [Tags]    bigcamera
@@ -79,4 +78,4 @@ Verify BigCamera OfflineDetailedStates
 
 Verify BigCamera OfflineDetailedStates timing
     [Tags]    bigcamera    detailed_states    timing
-    Verify Time Delta    ${BigCamera}    logevent_summaryState    ${offdet_topic}    ${time_window}
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    ${offdet_topic}

--- a/QueryEfd.py
+++ b/QueryEfd.py
@@ -153,7 +153,7 @@ class QueryEfd:
             csc=csc, topic=topic, fields=fields, num=num, index=index
         )
         try:
-            event_sent_time = recent_samples.private_sndStamp[0]
+            event_sent_time = recent_samples.private_sndStamp.iloc[0]
         except AttributeError:
             raise AttributeError(
                 "'DataFrame' object has no attribute 'private_sndStamp'"
@@ -273,8 +273,8 @@ class QueryEfd:
             raise AttributeError("SummaryState Event Not Found.")
         # Get the States.
         expected_state_str = state_enums.as_state(int(expected_state)).name
-        actual_state_str = state_enums.as_state(int(ss_df.summaryState[0])).name
-        event_sent_time = ss_df.private_sndStamp[0].strftime(self.time_format)
+        actual_state_str = state_enums.as_state(int(ss_df.summaryState.iloc[0])).name
+        event_sent_time = ss_df.private_sndStamp.iloc[0].strftime(self.time_format)
         # Pass if CSC is in expected_state and raise AssertionError if not.
         if str(actual_state_str) == str(expected_state_str):
             print(f"{csc_str} in {expected_state_str} State")
@@ -359,9 +359,9 @@ class QueryEfd:
                 raise ValueError("Dataframe should be empty")
         else:
             # Get the various field values.
-            configurations = dataframe.configurations[0]
-            version = dataframe.version[0].strip("tags/")
-            url = dataframe.url[0]
+            configurations = dataframe.configurations.iloc[0]
+            version = dataframe.version.iloc[0].strip("tags/")
+            url = dataframe.url.iloc[0]
             print(
                 f"*TRACE*Configurations: {configurations}, Version: {version}, URL: {url}"
             )
@@ -382,8 +382,8 @@ class QueryEfd:
                 self.verify_version(version)
             except AssertionError as e:
                 error_list.append("Config " + str(e))
-            if len(dataframe.otherInfo[0]) > 0:
-                events = dataframe.otherInfo[0].split(",")
+            if len(dataframe.otherInfo.iloc[0]) > 0:
+                events = dataframe.otherInfo.iloc[0].split(",")
                 for event in events:
                     if (
                         csc.lower() in ("atcamera", "cccamera", "mtcamera")
@@ -433,10 +433,10 @@ class QueryEfd:
                 raise ValueError("Dataframe should be empty")
         else:
             # Get the various field values.
-            version = dataframe.version[0].strip("tags/")
-            url = dataframe.url[0]
-            schema_version = dataframe.schemaVersion[0]
-            overrides = dataframe.overrides[0]
+            version = dataframe.version.iloc[0].strip("tags/")
+            url = dataframe.url.iloc[0]
+            schema_version = dataframe.schemaVersion.iloc[0]
+            overrides = dataframe.overrides.iloc[0]
             # Verify field values.
             print(
                 f"*TRACE*Overrides: '{overrides}', Version: '{version}', URL: '{url}', SchemaVersion: '{schema_version}'"
@@ -502,10 +502,10 @@ class QueryEfd:
         if dataframe.empty:
             raise ValueError("Dataframe is empty")
         # Get the dependency versions.
-        sal_ver = dataframe.salVersion[0]
-        xml_ver = dataframe.xmlVersion[0]
-        ospl_ver = dataframe.openSpliceVersion[0]
-        csc_ver = dataframe.cscVersion[0]
+        sal_ver = dataframe.salVersion.iloc[0]
+        xml_ver = dataframe.xmlVersion.iloc[0]
+        ospl_ver = dataframe.openSpliceVersion.iloc[0]
+        csc_ver = dataframe.cscVersion.iloc[0]
         print(
             f"*TRACE*Expected: SALVersion: {csc_salver}, XMLVersion: {csc_xmlver}, OSPLVersion: {self.ospl_version}",
             f"\n  Actual: SALVersion: {sal_ver}, XMLVersion: {xml_ver}, OSPLVersion: {ospl_ver}, CSCVersion: {csc_ver}",
@@ -573,7 +573,7 @@ class QueryEfd:
         else:
             topic_df = self.get_recent_samples(csc, topic, fields, 1, index)
             print(f"*TRACE*dataframe:\n{topic_df}")
-            actual_value = getattr(topic_df, attribute)[0]
+            actual_value = getattr(topic_df, attribute).iloc[0]
         failure = False
         if type(expected_values[0]) == int or type(expected_values[0]) == float:
             if not math.isclose(actual_value, expected_values[0], abs_tol=0.0001):

--- a/QueryEfd.py
+++ b/QueryEfd.py
@@ -631,10 +631,10 @@ class QueryEfd:
 
     @keyword
     def verify_time_delta(
-        self, csc: str, topic_1: str, topic_2: str, time_window: int, index: int = None
+        self, csc: str, topic_1: str, topic_2: str, index: int = None
     ) -> None:
         """Fails if the difference between the publish times for the two given
-        topics is greater than the given time_window..
+        topics is negative, indicating the second occurred BEFORE the first.
 
         Parameters
         ----------
@@ -644,9 +644,6 @@ class QueryEfd:
             The name of the first topic.
         topic_2 : `str`
             The name of the second topic.
-        time_window : `int`
-            The value, in seconds, under which publish times
-            should differ..
         index : `int`
             The index of the CSC, if applicable (default is None).
         """
@@ -654,16 +651,15 @@ class QueryEfd:
         time_1 = self.get_topic_sent_time(csc, topic_1)
         time_2 = self.get_topic_sent_time(csc, topic_2)
         # Get the timedelta, in seconds.
-        delta = abs((time_2 - time_1).total_seconds())
+        delta = (time_2 - time_1).total_seconds()
         print(
             f"*TRACE*{topic_1} was sent at {time_1}.\n"
             f"*TRACE*{topic_2} was sent at {time_2}.\n"
             f"*TRACE*The time difference is {delta} seconds."
         )
-        if delta > time_window:
+        if delta < 0:
             raise AssertionError(
-                f"{topic_2} was published {delta}s outside "
-                f"the {time_window}s time window from {topic_1}."
+                f"{topic_2} was published {abs(delta)} seconds BEFORE {topic_1}."
             )
 
     @keyword

--- a/Shutdown/Verify_ATCS_Shutdown.robot
+++ b/Shutdown/Verify_ATCS_Shutdown.robot
@@ -8,41 +8,40 @@ Suite Setup    Log Many    ${STATES}[offline]
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify ATAOS Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATAOS
-    Verify Time Delta    ATAOS    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATAOS    ${topic_1}    ${topic_2}
 
 Verify ATDome Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATDome
-    Verify Time Delta    ATDome    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATDome    ${topic_1}    ${topic_2}
 
 Verify ATDomeTrajectory Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATDomeTrajectory
-    Verify Time Delta    ATDomeTrajectory    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATDomeTrajectory    ${topic_1}    ${topic_2}
 
 Verify ATHexapod Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATHexapod
-    Verify Time Delta    ATHexapod    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATHexapod    ${topic_1}    ${topic_2}
 
 Verify ATMCS Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATMCS
-    Verify Time Delta    ATMCS    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATMCS    ${topic_1}    ${topic_2}
 
 Verify ATPneumatics Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATPneumatics
-    Verify Time Delta    ATPneumatics    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATPneumatics    ${topic_1}    ${topic_2}
 
 Verify ATPtg Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATPtg
-    Verify Time Delta    ATPtg    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATPtg    ${topic_1}    ${topic_2}
 

--- a/Shutdown/Verify_AT_Light_Cal_Shutdown.robot
+++ b/Shutdown/Verify_AT_Light_Cal_Shutdown.robot
@@ -7,15 +7,14 @@ Force Tags    shutdown    skipped
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify ATMonochromator Shutdown
     [Tags]    at_light_cal
     Verify Shutdown Process    ATMonochromator
-    Verify Time Delta    ATMonochromator    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATMonochromator    ${topic_1}    ${topic_2}
 
 Verify FiberSpectrograph:3 Shutdown
     [Tags]    at_light_cal
     Verify Shutdown Process    FiberSpectrograph    index=3
-    Verify Time Delta    FiberSpectrograph    ${topic_1}    ${topic_2}    ${time_window}    index=3
+    Verify Time Delta    FiberSpectrograph    ${topic_1}    ${topic_2}    index=3

--- a/Shutdown/Verify_BigCamera_Shutdown.robot
+++ b/Shutdown/Verify_BigCamera_Shutdown.robot
@@ -8,25 +8,24 @@ Suite Setup   Set EFD Values
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify Camera Shutdown
     [Tags]
     Verify Shutdown Process    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ${BigCamera}    ${topic_1}    ${topic_2}
 
 Verify OODS Shutdown
     [Tags]
     Verify Shutdown Process    ${OODS}
-    Verify Time Delta    ${OODS}    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ${OODS}    ${topic_1}    ${topic_2}
 
 Verify HeaderService Shutdown
     [Tags]
     Verify Shutdown Process    ${HeaderService}
-    Verify Time Delta    ${HeaderService}    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ${HeaderService}    ${topic_1}    ${topic_2}
 
 Verify OCPS:2||3 Shutdown
     [Tags]
     Verify Shutdown Process    OCPS    index=${OcpsIndex}
-    Verify Time Delta    OCPS    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    OCPS    ${topic_1}    ${topic_2}    index=2

--- a/Shutdown/Verify_EAS_AE_Shutdown.robot
+++ b/Shutdown/Verify_EAS_AE_Shutdown.robot
@@ -7,20 +7,19 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify DSM:1 Shutdown
     [Tags]    eas_ae
     Verify Shutdown Process    DSM    index=1
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=1
 
 Verify DSM:2 Shutdown
     [Tags]    eas_ae
     Verify Shutdown Process    DSM    index=2
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=2
 
 Verify WeatherForecast Shutdown
     [Tags]    eas
     Verify Shutdown Process    WeatherForecast
-    Verify Time Delta    WeatherForecast    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    WeatherForecast    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_EAS_Shutdown.robot
+++ b/Shutdown/Verify_EAS_Shutdown.robot
@@ -7,88 +7,87 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 # DIMM
 Verify DIMM:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DIMM    index=1
-    Verify Time Delta    DIMM    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    DIMM    ${topic_1}    ${topic_2}    index=1
 
 Verify DIMM:2 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DIMM    index=2
-    Verify Time Delta    DIMM    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    DIMM    ${topic_1}    ${topic_2}    index=2
 
 #DSM
 Verify DSM:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DSM    index=1
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=1
 
 Verify DSM:2 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DSM    index=2
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=2
 
 # ESS
 Verify ESS:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=1
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=1
 
 Verify ESS:101 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=101
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=101
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=101
 
 Verify ESS:102 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=102
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=102
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=102
 
 Verify ESS:103 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=103
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=103
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=103
 
 Verify ESS:104 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=104
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=104
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=104
 
 Verify ESS:105 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=105
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=105
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=105
 
 Verify ESS:106 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=106
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=106
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=106
 
 Verify ESS:201 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=201
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=201
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=201
 
 Verify ESS:202 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=202
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=202
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=202
 
 Verify ESS:203 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=203
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=203
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=203
 
 Verify ESS:204 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=204
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=204
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=204
 
 Verify ESS:301 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=301
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    ${time_window}    index=301
+    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=301

--- a/Shutdown/Verify_GC_Shutdown.robot
+++ b/Shutdown/Verify_GC_Shutdown.robot
@@ -7,15 +7,14 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify GenericCamera:1 Shutdown
     [Tags]    gc
     Verify Shutdown Process    GenericCamera    index=1
-    Verify Time Delta    GenericCamera    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    GenericCamera    ${topic_1}    ${topic_2}    index=1
 
 Verify GCHeaderService:1 Shutdown
     [Tags]    gc
     Verify Shutdown Process    GCHeaderService    index=1
-    Verify Time Delta    GCHeaderService    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    GCHeaderService    ${topic_1}    ${topic_2}    index=1

--- a/Shutdown/Verify_LATISS_Shutdown.robot
+++ b/Shutdown/Verify_LATISS_Shutdown.robot
@@ -7,30 +7,29 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify ATCamera Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATCamera
-    Verify Time Delta    ATCamera    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATCamera    ${topic_1}    ${topic_2}
 
 Verify ATHeaderService Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATHeaderService
-    Verify Time Delta    ATHeaderService    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATHeaderService    ${topic_1}    ${topic_2}
 
 Verify OCPS:1 Shutdown
     [Tags]    obsys2
     Verify Shutdown Process    OCPS    index=1
-    Verify Time Delta    OCPS    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    OCPS    ${topic_1}    ${topic_2}    index=1
 
 Verify ATOODS Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATOODS
-    Verify Time Delta    ATOODS    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATOODS    ${topic_1}    ${topic_2}
 
 Verify ATSpectrograph Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATSpectrograph
-    Verify Time Delta    ATSpectrograph    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    ATSpectrograph    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_MTCS_Shutdown.robot
+++ b/Shutdown/Verify_MTCS_Shutdown.robot
@@ -7,70 +7,69 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify LaserTracker:1 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    LaserTracker    index=1
-    Verify Time Delta    LaserTracker    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    LaserTracker    ${topic_1}    ${topic_2}    index=1
 
 Verify MTAirCompressor:1 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTAirCompressor    index=1
-    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    index=1
 
 Verify MTAirCompressor:2 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTAirCompressor    index=2
-    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    index=2
 
 Verify MTMount Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTMount
-    Verify Time Delta    MTMount    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTMount    ${topic_1}    ${topic_2}
 
 Verify MTPtg Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTPtg
-    Verify Time Delta    MTPtg    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTPtg    ${topic_1}    ${topic_2}
 
 Verify MTDome Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTDome
-    Verify Time Delta    MTDome    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTDome    ${topic_1}    ${topic_2}
 
 Verify MTDomeTrajectory Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTDomeTrajectory
-    Verify Time Delta    MTDomeTrajectory    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTDomeTrajectory    ${topic_1}    ${topic_2}
 
 Verify MTAOS Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTAOS
-    Verify Time Delta    MTAOS    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTAOS    ${topic_1}    ${topic_2}
 
 Verify MTHexapod:1 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTHexapod    index=1
-    Verify Time Delta    MTHexapod    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    MTHexapod    ${topic_1}    ${topic_2}    index=1
 
 Verify MTHexapod:2 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTHexapod    index=2
-    Verify Time Delta    MTHexapod    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    MTHexapod    ${topic_1}    ${topic_2}    index=2
 
 Verify MTRotator Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTRotator
-    Verify Time Delta    MTRotator    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTRotator    ${topic_1}    ${topic_2}
 
 Verify MTM1M3 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTM1M3
-    Verify Time Delta    MTM1M3    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTM1M3    ${topic_1}    ${topic_2}
 
 Verify MTM2 Shutdown
     [Tags]    mtcs
     Verify Shutdown Process    MTM2
-    Verify Time Delta    MTM2    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    MTM2    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_ObsSys1_Shutdown.robot
+++ b/Shutdown/Verify_ObsSys1_Shutdown.robot
@@ -7,25 +7,24 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify Authorize Shutdown
     [Tags]    obssys1
     Verify Shutdown Process    Authorize
-    Verify Time Delta    Authorize    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    Authorize    ${topic_1}    ${topic_2}
 
 Verify ScriptQueue:1 Shutdown
     [Tags]    obssys1
     Verify Shutdown Process    ScriptQueue    1
-    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    index=1
 
 Verify ScriptQueue:2 Shutdown
     [Tags]    obssys1
     Verify Shutdown Process    ScriptQueue    index=2
-    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    index=2
 
 Verify Watcher Shutdown
     [Tags]    obssys1
     Verify Shutdown Process    Watcher
-    Verify Time Delta    Watcher    ${topic_1}    ${topic_2}    ${time_window}
+    Verify Time Delta    Watcher    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_ObsSys2_Shutdown.robot
+++ b/Shutdown/Verify_ObsSys2_Shutdown.robot
@@ -7,15 +7,14 @@ Force Tags    shutdown
 *** Variables ***
 ${topic_1}    logevent_summaryState
 ${topic_2}    command_disable
-${time_window}    600
 
 *** Test Cases ***
 Verify Scheduler:1 Shutdown
     [Tags]    obssys2
     Verify Shutdown Process    Scheduler    index=1
-    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    ${time_window}    index=1
+    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    index=1
 
 Verify Scheduler:2 Shutdown
     [Tags]    obssys2
     Verify Shutdown Process    Scheduler    index=2
-    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    ${time_window}    index=2
+    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    index=2

--- a/Standby/Execute_Offline_Standby.robot
+++ b/Standby/Execute_Offline_Standby.robot
@@ -5,7 +5,6 @@ Resource    ../Common_Keywords.resource
 Force Tags    standby    execute
 
 *** Variables ***
-${time_window}    10
 
 *** Test Cases ***
 Execute AuxTel Offline to Standby

--- a/Standby/Verify_ATCS_Standby.robot
+++ b/Standby/Verify_ATCS_Standby.robot
@@ -19,7 +19,6 @@ ${atpneumatics_salver}    ${SALVersion}
 ${atpneumatics_xmlver}    ${XMLVersion}
 ${atptg_salver}    ${SALVersion}
 ${atptg_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 #ATAOS
@@ -33,7 +32,7 @@ Verify ATAOS SoftwareVersions
 
 Verify ATAOS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATAOS    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATAOS    logevent_summaryState    logevent_softwareVersions
 
 Verify ATAOS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -41,7 +40,7 @@ Verify ATAOS ConfigurationsAvailable Event
 
 Verify ATAOS ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATAOS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATAOS    logevent_summaryState    logevent_configurationsAvailable
 
 #ATDome
 Verify ATDome Standby
@@ -54,7 +53,7 @@ Verify ATDome SoftwareVersions
 
 Verify ATDome SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATDome    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATDome    logevent_summaryState    logevent_softwareVersions
 
 Verify ATDome ConfigurationsAvailable Event
     [Tags]    config_available
@@ -62,7 +61,7 @@ Verify ATDome ConfigurationsAvailable Event
 
 Verify ATDome ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATDome    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATDome    logevent_summaryState    logevent_configurationsAvailable
 
 Verify ATDomeTrajectory Standby
     [Tags]    standby
@@ -75,7 +74,7 @@ Verify ATDomeTrajectory SoftwareVersions
 
 Verify ATDomeTrajectory SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    logevent_softwareVersions
 
 Verify ATDomeTrajectory ConfigurationsAvailable Event
     [Tags]    config_available
@@ -83,7 +82,7 @@ Verify ATDomeTrajectory ConfigurationsAvailable Event
 
 Verify ATDomeTrajectory ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    logevent_configurationsAvailable
 
 #ATHexapod
 Verify ATHexapod Standby
@@ -96,7 +95,7 @@ Verify ATHexapod SoftwareVersions
 
 Verify ATHexapod SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATHexapod    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATHexapod    logevent_summaryState    logevent_softwareVersions
 
 Verify ATHexapod ConfigurationsAvailable Event
     [Tags]    config_available
@@ -104,7 +103,7 @@ Verify ATHexapod ConfigurationsAvailable Event
 
 Verify ATHexapod ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATHexapod    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATHexapod    logevent_summaryState    logevent_configurationsAvailable
 
 #ATMCS
 Verify ATMCS Standby
@@ -117,7 +116,7 @@ Verify ATMCS SoftwareVersions
 
 Verify ATMCS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMCS    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATMCS    logevent_summaryState    logevent_softwareVersions
 
 Verify ATMCS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -134,7 +133,7 @@ Verify ATPneumatics SoftwareVersions
 
 Verify ATPneumatics SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATPneumatics    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATPneumatics    logevent_summaryState    logevent_softwareVersions
 
 Verify ATPneumatics ConfigurationsAvailable Event
     [Tags]    config_available
@@ -151,7 +150,7 @@ Verify ATPtg SoftwareVersions
 
 Verify ATPtg SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATPtg    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATPtg    logevent_summaryState    logevent_softwareVersions
 
 Verify ATPtg ConfigurationsAvailable Event
     [Tags]    config_available

--- a/Standby/Verify_AT_Light_Cal_Standby.robot
+++ b/Standby/Verify_AT_Light_Cal_Standby.robot
@@ -9,7 +9,6 @@ ${atmonochromator_salver}    ${SALVersion}
 ${atmonochromator_xmlver}    ${XMLVersion}
 ${fiberspectrograph_salver}    ${SALVersion}
 ${fiberspectrograph_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 #ATMonochromator
@@ -23,7 +22,7 @@ Verify ATMonochromator SoftwareVersions
 
 Verify ATMonochromator SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_softwareVersions
 
 Verify ATMonochromator ConfigurationsAvailable Event
     [Tags]    config_available
@@ -31,7 +30,7 @@ Verify ATMonochromator ConfigurationsAvailable Event
 
 Verify ATMonochromator ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_configurationsAvailable
 
 #FiberSpectrograph:3
 Verify FiberSpectrograph:3 Standby
@@ -44,7 +43,7 @@ Verify FiberSpectrograph:3 SoftwareVersions
 
 Verify FiberSpectrograph:3 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_softwareVersions    ${time_window}    3
+    Verify Time Delta    ATMonochromator    logevent_summaryState    logevent_softwareVersions    3
 
 Verify FiberSpectrograph:3 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -52,4 +51,4 @@ Verify FiberSpectrograph:3 ConfigurationsAvailable Event
 
 Verify FiberSpectrograph:3 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    FiberSpectrograph    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    3
+    Verify Time Delta    FiberSpectrograph    logevent_summaryState    logevent_configurationsAvailable    3

--- a/Standby/Verify_BigCamera_Standby.robot
+++ b/Standby/Verify_BigCamera_Standby.robot
@@ -22,7 +22,6 @@ ${ocps2_salver}    ${SALVersion}
 ${ocps2_xmlver}    ${XMLVersion}
 ${ocps3_salver}    ${SALVersion}
 ${ocps3_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 #BigCamera
@@ -36,7 +35,7 @@ Verify BigCamera SoftwareVersions
 
 Verify BigCamera SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_softwareVersions
 
 Verify BigCamera ConfigurationsAvailable Event
     [Tags]    config_available
@@ -44,7 +43,7 @@ Verify BigCamera ConfigurationsAvailable Event
 
 Verify BigCamera ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_configurationsAvailable
 
 #OODS
 Verify OODS Standby
@@ -57,7 +56,7 @@ Verify OODS SoftwareVersions
 
 Verify OODS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ${OODS}    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ${OODS}    logevent_summaryState    logevent_softwareVersions
 
 Verify OODS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -78,7 +77,7 @@ Verify HeaderService SoftwareVersions
 
 Verify HeaderService SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ${HeaderService}    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ${HeaderService}    logevent_summaryState    logevent_softwareVersions
 
 #OCPS:2||3
 Verify OCPS:2||3 Standby
@@ -91,7 +90,7 @@ Verify OCPS:2||3 SoftwareVersions
 
 Verify OCPS:2||3 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    OCPS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=${OcpsIndex}
+    Verify Time Delta    OCPS    logevent_summaryState    logevent_softwareVersions    index=${OcpsIndex}
 
 Verify OCPS:2||3 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -99,4 +98,4 @@ Verify OCPS:2||3 ConfigurationsAvailable Event
 
 Verify OCPS:2||3 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=${OcpsIndex}
+    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationsAvailable    index=${OcpsIndex}

--- a/Standby/Verify_EAS_AE_Standby.robot
+++ b/Standby/Verify_EAS_AE_Standby.robot
@@ -11,7 +11,6 @@ ${dsm2_salver}    ${SALVersion}
 ${dsm2_xmlver}    ${XMLVersion}
 ${weatherforecast_salver}    ${SALVersion}
 ${weatherforecast_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 # DSM:1
@@ -25,7 +24,7 @@ Verify DSM:1 SoftwareVersions
 
 Verify DSM:1 SoftwareVersions timing
     [Tags]    eas_ae    software_versions    timing
-    Verify Time Delta    DSM    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    DSM    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify DSM:1 ConfigurationsAvailable Event
     [Tags]    eas_ae    config_available
@@ -42,7 +41,7 @@ Verify DSM:2 SoftwareVersions
 
 Verify DSM:2 SoftwareVersions timing
     [Tags]    eas_ae    software_versions    timing
-    Verify Time Delta    DSM    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=2
+    Verify Time Delta    DSM    logevent_summaryState    logevent_softwareVersions    index=2
 
 Verify DSM:2 ConfigurationsAvailable Event
     [Tags]    eas_ae    config_available
@@ -59,7 +58,7 @@ Verify WeatherForecast SoftwareVersions
 
 Verify WeatherForecast SoftwareVersions timing
     [Tags]    eas_ae    software_versions    timing
-    Verify Time Delta    WeatherForecast    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    WeatherForecast    logevent_summaryState    logevent_softwareVersions
 
 Verify WeatherForecast ConfigurationsAvailable Event
     [Tags]    eas_ae    config_available

--- a/Standby/Verify_EAS_Standby.robot
+++ b/Standby/Verify_EAS_Standby.robot
@@ -33,7 +33,6 @@ ${ess204_salver}    ${SALVersion}
 ${ess204_xmlver}    ${XMLVersion}
 ${ess301_salver}    ${SALVersion}
 ${ess301_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 # DIMM:1
@@ -47,7 +46,7 @@ Verify DIMM:1 SoftwareVersions
 
 Verify DIMM:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    DIMM    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify DIMM:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -55,7 +54,7 @@ Verify DIMM:1 ConfigurationsAvailable Event
 
 Verify DIMM:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 # DIMM:2
 Verify DIMM:2 Standby
@@ -68,7 +67,7 @@ Verify DIMM:2 SoftwareVersions
 
 Verify DIMM:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=2
+    Verify Time Delta    DIMM    logevent_summaryState    logevent_softwareVersions    index=2
 
 Verify DIMM:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -76,7 +75,7 @@ Verify DIMM:2 ConfigurationsAvailable Event
 
 Verify DIMM:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=2
+    Verify Time Delta    DIMM    logevent_summaryState    logevent_configurationsAvailable    index=2
 
 # ESS:1
 Verify ESS:1 Standby
@@ -89,7 +88,7 @@ Verify ESS:1 SoftwareVersions
 
 Verify ESS:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify ESS:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -97,7 +96,7 @@ Verify ESS:1 ConfigurationsAvailable Event
 
 Verify ESS:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 # ESS:101
 Verify ESS:101 Standby
@@ -110,7 +109,7 @@ Verify ESS:101 SoftwareVersions
     
 Verify ESS:101 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=101
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=101
 
 Verify ESS:101 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -118,7 +117,7 @@ Verify ESS:101 ConfigurationsAvailable Event
 
 Verify ESS:101 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=101
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=101
 
 # ESS:102
 Verify ESS:102 Standby
@@ -131,7 +130,7 @@ Verify ESS:102 SoftwareVersions
     
 Verify ESS:102 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=102
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=102
 
 Verify ESS:102 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -139,7 +138,7 @@ Verify ESS:102 ConfigurationsAvailable Event
 
 Verify ESS:102 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=102
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=102
 
 # ESS:103
 Verify ESS:103 Standby
@@ -152,7 +151,7 @@ Verify ESS:103 SoftwareVersions
     
 Verify ESS:103 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=103
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=103
 
 Verify ESS:103 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -160,7 +159,7 @@ Verify ESS:103 ConfigurationsAvailable Event
 
 Verify ESS:103 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=103
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=103
 
 # ESS:104
 Verify ESS:104 Standby
@@ -173,7 +172,7 @@ Verify ESS:104 SoftwareVersions
     
 Verify ESS:104 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=104
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=104
 
 Verify ESS:104 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -181,7 +180,7 @@ Verify ESS:104 ConfigurationsAvailable Event
 
 Verify ESS:104 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=104
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=104
 
 # ESS:105
 Verify ESS:105 Standby
@@ -194,7 +193,7 @@ Verify ESS:105 SoftwareVersions
     
 Verify ESS:105 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=105
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=105
     
 Verify ESS:105 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -202,7 +201,7 @@ Verify ESS:105 ConfigurationsAvailable Event
     
 Verify ESS:105 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=105
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=105
 
 # ESS:106
 Verify ESS:106 Standby
@@ -215,7 +214,7 @@ Verify ESS:106 SoftwareVersions
     
 Verify ESS:106 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=106
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=106
    
 Verify ESS:106 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -223,7 +222,7 @@ Verify ESS:106 ConfigurationsAvailable Event
    
 Verify ESS:106 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=106
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=106
 
 # ESS:201
 Verify ESS:201 Standby
@@ -236,7 +235,7 @@ Verify ESS:201 SoftwareVersions
 
 Verify ESS:201 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=201
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=201
 
 Verify ESS:201 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -244,7 +243,7 @@ Verify ESS:201 ConfigurationsAvailable Event
 
 Verify ESS:201 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=201
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=201
 
 # ESS:202
 Verify ESS:202 Standby
@@ -257,7 +256,7 @@ Verify ESS:202 SoftwareVersions
 
 Verify ESS:202 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=202
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=202
 
 Verify ESS:202 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -265,7 +264,7 @@ Verify ESS:202 ConfigurationsAvailable Event
 
 Verify ESS:202 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=202
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=202
 
 # ESS:203
 Verify ESS:203 Standby
@@ -278,7 +277,7 @@ Verify ESS:203 SoftwareVersions
 
 Verify ESS:203 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=203
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=203
 
 Verify ESS:203 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -286,7 +285,7 @@ Verify ESS:203 ConfigurationsAvailable Event
 
 Verify ESS:203 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=203
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=203
 
 # ESS:204
 Verify ESS:204 Standby
@@ -299,7 +298,7 @@ Verify ESS:204 SoftwareVersions
 
 Verify ESS:204 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=204
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=204
 
 Verify ESS:204 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -307,7 +306,7 @@ Verify ESS:204 ConfigurationsAvailable Event
 
 Verify ESS:204 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=204
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=204
 
 # ESS:301
 Verify ESS:301 Standby
@@ -320,7 +319,7 @@ Verify ESS:301 SoftwareVersions
 
 Verify ESS:301 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=301
+    Verify Time Delta    ESS    logevent_summaryState    logevent_softwareVersions    index=301
 
 Verify ESS:301 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -328,4 +327,4 @@ Verify ESS:301 ConfigurationsAvailable Event
 
 Verify ESS:301 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=301
+    Verify Time Delta    ESS    logevent_summaryState    logevent_configurationsAvailable    index=301

--- a/Standby/Verify_GC_Standby.robot
+++ b/Standby/Verify_GC_Standby.robot
@@ -9,7 +9,6 @@ ${genericcamera_salver}    ${SALVersion}
 ${genericcamera_xmlver}    ${XMLVersion}
 ${gcheaderservice_salver}    ${SALVersion}
 ${gcheaderservice_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 Verify GenericCamera:1 Standby
@@ -22,7 +21,7 @@ Verify GenericCamera:1 SoftwareVersions
 
 Verify GenericCamera:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    GenericCamera    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    GenericCamera    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify GenericCamera:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -30,7 +29,7 @@ Verify GenericCamera:1 ConfigurationsAvailable Event
 
 Verify GenericCamera:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    GenericCamera    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    GenericCamera    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 Verify GCHeaderService:1 Standby
     [Tags]    standby
@@ -42,7 +41,7 @@ Verify GCHeaderService:1 SoftwareVersions
 
 Verify GCHeaderService:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    GCHeaderService    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    GCHeaderService    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify GCHeaderService:1 ConfigurationsAvailable Event
     [Tags]    config_available

--- a/Standby/Verify_LATISS_Standby.robot
+++ b/Standby/Verify_LATISS_Standby.robot
@@ -15,7 +15,6 @@ ${atoods_salver}    ${SALVersion}
 ${atoods_xmlver}    ${XMLVersion}
 ${atspectrograph_salver}    ${SALVersion}
 ${atspectrograph_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 #ATCamera
@@ -29,7 +28,7 @@ Verify ATCamera SoftwareVersions
 
 Verify ATCamera SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATCamera    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATCamera    logevent_summaryState    logevent_softwareVersions
 
 Verify ATCamera ConfigurationsAvailable Event
     [Tags]    config_available
@@ -37,7 +36,7 @@ Verify ATCamera ConfigurationsAvailable Event
 
 Verify ATCamera ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATCamera    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATCamera    logevent_summaryState    logevent_configurationsAvailable
 
 #ATOODS
 Verify ATOODS Standby
@@ -50,7 +49,7 @@ Verify ATOODS SoftwareVersions
 
 Verify ATOODS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATOODS    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATOODS    logevent_summaryState    logevent_softwareVersions
 
 Verify ATOODS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -67,7 +66,7 @@ Verify ATHeaderService SoftwareVersions
 
 Verify ATHeaderService SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATHeaderService    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATHeaderService    logevent_summaryState    logevent_softwareVersions
 
 Verify ATHeaderService ConfigurationsAvailable Event
     [Tags]    config_available
@@ -84,7 +83,7 @@ Verify OCPS:1 SoftwareVersions
 
 Verify OCPS:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    OCPS    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    OCPS    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify OCPS:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -92,7 +91,7 @@ Verify OCPS:1 ConfigurationsAvailable Event
 
 Verify OCPS:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    1
+    Verify Time Delta    OCPS    logevent_summaryState    logevent_configurationsAvailable    1
 
 #ATSpectrograph
 Verify ATSpectrograph Standby
@@ -105,7 +104,7 @@ Verify ATSpectrograph SoftwareVersions
 
 Verify ATSpectrograph SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATSpectrograph    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    ATSpectrograph    logevent_summaryState    logevent_softwareVersions
 
 Verify ATSpectrograph ConfigurationsAvailable Event
     [Tags]    config_available
@@ -113,4 +112,4 @@ Verify ATSpectrograph ConfigurationsAvailable Event
 
 Verify ATSpectrograph ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATSpectrograph    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    ATSpectrograph    logevent_summaryState    logevent_configurationsAvailable

--- a/Standby/Verify_MTCS_Standby.robot
+++ b/Standby/Verify_MTCS_Standby.robot
@@ -33,7 +33,6 @@ ${mtm2_salver}    ${SALVersion}
 ${mtm2_xmlver}    ${XMLVersion}
 @{in_position_field}    inPosition
 @{in_position}    False
-${time_window}    10
 
 *** Test Cases ***
 #LaserTracker:1
@@ -47,7 +46,7 @@ Verify LaserTracker:1 SoftwareVersions
 
 Verify LaserTracker:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    LaserTracker    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    LaserTracker    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify LaserTracker:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -55,7 +54,7 @@ Verify LaserTracker:1 ConfigurationsAvailable Event
 
 Verify LaserTracker:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    LaserTracker    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    LaserTracker    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 #MTAirCompressor:1
 Verify MTAirCompressor:1 Standby
@@ -68,7 +67,7 @@ Verify MTAirCompressor:1 SoftwareVersions
 
 Verify MTAirCompressor:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify MTAirCompressor:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -76,7 +75,7 @@ Verify MTAirCompressor:1 ConfigurationsAvailable Event
 
 Verify MTAirCompressor:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 #MTAirCompressor:2
 Verify MTAirCompressor:2 Standby
@@ -89,7 +88,7 @@ Verify MTAirCompressor:2 SoftwareVersions
 
 Verify MTAirCompressor:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=2
+    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_softwareVersions    index=2
 
 Verify MTAirCompressor:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -97,7 +96,7 @@ Verify MTAirCompressor:2 ConfigurationsAvailable Event
 
 Verify MTAirCompressor:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=2
+    Verify Time Delta    MTAirCompressor    logevent_summaryState    logevent_configurationsAvailable    index=2
 
 #MTMount
 Verify MTMount Standby
@@ -115,7 +114,7 @@ Verify MTMount SoftwareVersions
 
 Verify MTMount SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTMount    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTMount    logevent_summaryState    logevent_softwareVersions
 
 Verify MTMount ConfigurationsAvailable Event
     [Tags]    config_available
@@ -123,7 +122,7 @@ Verify MTMount ConfigurationsAvailable Event
 
 Verify MTMount ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTMount    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTMount    logevent_summaryState    logevent_configurationsAvailable
 
 # MTPtg
 Verify MTPtg Standby
@@ -136,7 +135,7 @@ Verify MTPtg SoftwareVersions
 
 Verify MTPtg SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTPtg    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTPtg    logevent_summaryState    logevent_softwareVersions
 
 Verify MTPtg ConfigurationsAvailable Event
     [Tags]    config_available
@@ -153,7 +152,7 @@ Verify MTDome SoftwareVersions
 
 Verify MTDome SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTDome    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTDome    logevent_summaryState    logevent_softwareVersions
 
 Verify MTDome ConfigurationsAvailable Event
     [Tags]    config_available
@@ -161,7 +160,7 @@ Verify MTDome ConfigurationsAvailable Event
 
 Verify MTDome ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTDome    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTDome    logevent_summaryState    logevent_configurationsAvailable
 
 #MTDomeTrajectory
 Verify MTDomeTrajectory Standby
@@ -174,7 +173,7 @@ Verify MTDomeTrajectory SoftwareVersions
 
 Verify MTDomeTrajectory SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    logevent_softwareVersions
 
 Verify MTDomeTrajectory ConfigurationsAvailable Event
     [Tags]    config_available
@@ -182,7 +181,7 @@ Verify MTDomeTrajectory ConfigurationsAvailable Event
 
 Verify MTDomeTrajectory ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    logevent_configurationsAvailable
 
 # MTAOS
 Verify MTAOS Standby
@@ -195,7 +194,7 @@ Verify MTAOS SoftwareVersions
 
 Verify MTAOS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAOS    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTAOS    logevent_summaryState    logevent_softwareVersions
 
 Verify MTAOS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -203,7 +202,7 @@ Verify MTAOS ConfigurationsAvailable Event
 
 Verify MTAOS ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTAOS    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTAOS    logevent_summaryState    logevent_configurationsAvailable
 
 # MTHexapod:1
 Verify MTHexapod:1 Standby
@@ -216,7 +215,7 @@ Verify MTHexapod:1 SoftwareVersions
 
 Verify MTHexapod:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify MTHexapod:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -224,7 +223,7 @@ Verify MTHexapod:1 ConfigurationsAvailable Event
 
 Verify MTHexapod:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 # MTHexapod:2
 Verify MTHexapod:2 Standby
@@ -237,7 +236,7 @@ Verify MTHexapod:2 SoftwareVersions
 
 Verify MTHexapod:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=2
+    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_softwareVersions    index=2
 
 Verify MTHexapod:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -245,7 +244,7 @@ Verify MTHexapod:2 ConfigurationsAvailable Event
 
 Verify MTHexapod:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=2
+    Verify Time Delta    MTHexapod    logevent_summaryState    logevent_configurationsAvailable    index=2
 
 # MTRotator
 Verify MTRotator Standby
@@ -258,7 +257,7 @@ Verify MTRotator SoftwareVersions
 
 Verify MTRotator SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTRotator    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTRotator    logevent_summaryState    logevent_softwareVersions
 
 Verify MTRotator ConfigurationsAvailable Event
     [Tags]    config_available
@@ -266,7 +265,7 @@ Verify MTRotator ConfigurationsAvailable Event
 
 Verify MTRotator ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTRotator    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTRotator    logevent_summaryState    logevent_configurationsAvailable
 
 # MTM1M3
 Verify MTM1M3 Standby
@@ -279,7 +278,7 @@ Verify MTM1M3 SoftwareVersions
 
 Verify MTM1M3 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTM1M3    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTM1M3    logevent_summaryState    logevent_softwareVersions
 
 Verify MTM1M3 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -287,7 +286,7 @@ Verify MTM1M3 ConfigurationsAvailable Event
 
 Verify MTM1M3 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTM1M3    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTM1M3    logevent_summaryState    logevent_configurationsAvailable
 
 # MTM2
 Verify MTM2 Standby
@@ -300,7 +299,7 @@ Verify MTM2 SoftwareVersions
 
 Verify MTM2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTM2    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    MTM2    logevent_summaryState    logevent_softwareVersions
 
 Verify MTM2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -308,4 +307,4 @@ Verify MTM2 ConfigurationsAvailable Event
 
 Verify MTM2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTM2    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    MTM2    logevent_summaryState    logevent_configurationsAvailable

--- a/Standby/Verify_ObsSys1_Standby.robot
+++ b/Standby/Verify_ObsSys1_Standby.robot
@@ -13,7 +13,6 @@ ${scriptqueue2_salver}    ${SALVersion}
 ${scriptqueue2_xmlver}    ${XMLVersion}
 ${watcher_salver}    ${SALVersion}
 ${watcher_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 #Authorize
@@ -27,7 +26,7 @@ Verify Authorize SoftwareVersions
 
 Verify Authorize SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Authorize    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    Authorize    logevent_summaryState    logevent_softwareVersions
 
 #ScriptQueue:1
 Verify ScriptQueue:1 Standby
@@ -40,7 +39,7 @@ Verify ScriptQueue:1 SoftwareVersions
 
 Verify ScriptQueue:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ScriptQueue    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    ScriptQueue    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify ScriptQueue:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -57,7 +56,7 @@ Verify ScriptQueue:2 SoftwareVersions
 
 Verify ScriptQueue:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ScriptQueue    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=2
+    Verify Time Delta    ScriptQueue    logevent_summaryState    logevent_softwareVersions    index=2
 
 Verify ScriptQueue:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -74,7 +73,7 @@ Verify Watcher SoftwareVersions
 
 Verify Watcher SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Watcher    logevent_summaryState    logevent_softwareVersions    ${time_window}
+    Verify Time Delta    Watcher    logevent_summaryState    logevent_softwareVersions
 
 Verify Watcher ConfigurationsAvailable Event
     [Tags]    config_available
@@ -82,4 +81,4 @@ Verify Watcher ConfigurationsAvailable Event
 
 Verify Watcher ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    Watcher    logevent_summaryState    logevent_configurationsAvailable    ${time_window}
+    Verify Time Delta    Watcher    logevent_summaryState    logevent_configurationsAvailable

--- a/Standby/Verify_ObsSys2_Standby.robot
+++ b/Standby/Verify_ObsSys2_Standby.robot
@@ -9,7 +9,6 @@ ${scheduler1_salver}    ${SALVersion}
 ${scheduler1_xmlver}    ${XMLVersion}
 ${scheduler2_salver}    ${SALVersion}
 ${scheduler2_xmlver}    ${XMLVersion}
-${time_window}    10
 
 *** Test Cases ***
 #Scheduler:1
@@ -23,7 +22,7 @@ Verify Scheduler:1 SoftwareVersions
 
 Verify Scheduler:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Scheduler    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=1
+    Verify Time Delta    Scheduler    logevent_summaryState    logevent_softwareVersions    index=1
 
 Verify Scheduler:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -31,7 +30,7 @@ Verify Scheduler:1 ConfigurationsAvailable Event
 
 Verify Scheduler:1 ConfigurationsAvailable timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=1
+    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationsAvailable    index=1
 
 #Scheduler:2
 Verify Scheduler:2 Standby
@@ -44,7 +43,7 @@ Verify Scheduler:2 SoftwareVersions
 
 Verify Scheduler:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Scheduler    logevent_summaryState    logevent_softwareVersions    ${time_window}    index=2
+    Verify Time Delta    Scheduler    logevent_summaryState    logevent_softwareVersions    index=2
 
 Verify Scheduler:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -52,4 +51,4 @@ Verify Scheduler:2 ConfigurationsAvailable Event
 
 Verify Scheduler:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationsAvailable    ${time_window}    index=2
+    Verify Time Delta    Scheduler    logevent_summaryState    logevent_configurationsAvailable    index=2

--- a/Verify_AuxTel_Housekeeping.robot
+++ b/Verify_AuxTel_Housekeeping.robot
@@ -8,7 +8,6 @@ Suite Setup    Check If Failed
 *** Variables ***
 @{port_field}    selected
 @{instrument_port}    2    #Nasymth2
-${time_window}    10
 
 *** Test Cases ***
 Execute AuxTel Housekeeping

--- a/Verify_MainTel_Housekeeping.robot
+++ b/Verify_MainTel_Housekeeping.robot
@@ -10,7 +10,6 @@ Suite Setup    Run Keywords    Check If Failed    AND    Set EFD Values
 @{in_position}    True
 @{filter_field}   filterName
 @{filter_name}    r_03
-${time_window}    10
 
 *** Test Cases ***
 Execute MainTel Housekeeping
@@ -34,9 +33,9 @@ Verify Tracking is Disabled
 Verify MTMount Axes Homed
     [Tags]    robot:continue-on-failure
     Verify Topic Attribute    MTMount    logevent_elevationInPosition    ${in_position_field}    ${in_position}
-    Verify Time Delta    MTMount    command_homeBothAxes    logevent_elevationInPosition    ${time_window}    None
+    Verify Time Delta    MTMount    command_homeBothAxes    logevent_elevationInPosition    index=None
     Verify Topic Attribute    MTMount    logevent_azimuthInPosition    ${in_position_field}    ${in_position}
-    Verify Time Delta    MTMount    command_homeBothAxes    logevent_azimuthInPosition    ${time_window}    None
+    Verify Time Delta    MTMount    command_homeBothAxes    logevent_azimuthInPosition    index=None
 
 Verify BigCamera has Filter Set
     [Tags]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 chmod +x .miniconda.sh && ./.miniconda.sh -b -p miniconda3 && \
 source miniconda3/bin/activate && \
 conda update conda -y && \
-conda install python>=3.10 -y && \
+conda install -c conda-forge python>=3.11 -y && \
 conda env create -f .environment.yaml && \
 conda activate test_reporting && \
 pip3 install -U setuptools numpy pytest astropy requests robotframework lsst-efd-client

--- a/docker/environment.yaml
+++ b/docker/environment.yaml
@@ -1,3 +1,3 @@
 name: test_reporting
 dependencies:
-  - python=3.10
+  - python=3.11


### PR DESCRIPTION
* Refactor timing checks to ensure second topic was sent AFTER first, eschewing the time_window tolerance.