### PR TITLE
Cycle35 hotfixes

### DIFF
--- a/Disabled/Execute_Standby_Disabled.robot
+++ b/Disabled/Execute_Standby_Disabled.robot
@@ -43,9 +43,7 @@ Execute MainTel Standby to Disabled
 
 Execute ObsSys Standby to Disabled
     [Tags]    obssys
-    # Set the 'test_env' variable to 'bts' if running on the BTS, otherwise, set it to 'tts'.
-    ${test_env}=    Set Variable If    "${env_efd}" == "base_efd"    bts    tts
-    ${scripts}    ${states}=    Execute Integration Test    obssys_standby_disabled    ${test_env}
+    ${scripts}    ${states}=    Execute Integration Test    obssys_standby_disabled
     Verify Scripts Completed Successfully    ${scripts}    ${states}
     Report If Failed    ${scripts}    ${states}
 

--- a/Enabled/Execute_Disabled_Enabled.robot
+++ b/Enabled/Execute_Disabled_Enabled.robot
@@ -29,7 +29,9 @@ Execute EAS Disabled to Enabled
 
 Execute MainTel Disabled to Enabled
     [Tags]    mtcs
-    ${scripts}    ${states}=    Execute Integration Test    maintel_disabled_enabled
+    # Set the 'test_env' variable to 'bts' if running on the BTS, otherwise, set it to 'tts'.
+    ${test_env}=    Set Variable If    "${env_efd}" == "base_efd"    bts    tts
+    ${scripts}    ${states}=    Execute Integration Test    maintel_disabled_enabled    ${test_env}
     Verify Scripts Completed Successfully    ${scripts}    ${states}
     Report If Failed    ${scripts}    ${states}
 
@@ -41,7 +43,7 @@ Execute GenCam Disabled to Enabled
 
 Execute ObsSys Disabled to Enabled
     [Tags]    obssys
-    ${scripts}    ${states}=    Execute Integration Test    obssys_disabled_enabled    ${test_env}
+    ${scripts}    ${states}=    Execute Integration Test    obssys_disabled_enabled
     Verify Scripts Completed Successfully    ${scripts}    ${states}
     Report If Failed    ${scripts}    ${states}
 


### PR DESCRIPTION
MainTel state transition scripts still require the 'test_env' argument. The ObsSys scripts do not.