### PR TITLE
Tickets/dm44849: Updated all Timing tests to use the new strategy

### DIFF
--- a/Disabled/Verify_ATCS_Disabled.robot
+++ b/Disabled/Verify_ATCS_Disabled.robot
@@ -12,7 +12,7 @@ Verify ATAOS Disabled
 
 Verify ATAOS SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATAOS    command_start    logevent_summaryState
+    Verify Time Delta    ATAOS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATAOS ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify ATAOS ConfigurationApplied Event
 
 Verify ATAOS ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATAOS    command_start    logevent_configurationApplied
+    Verify Time Delta    ATAOS    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATDome
 Verify ATDome Disabled
@@ -29,7 +29,7 @@ Verify ATDome Disabled
 
 Verify ATDome SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATDome    command_start    logevent_summaryState
+    Verify Time Delta    ATDome    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATDome ConfigurationApplied Event
     [Tags]    config_applied
@@ -37,7 +37,7 @@ Verify ATDome ConfigurationApplied Event
 
 Verify ATDome ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATDome    command_start    logevent_configurationApplied
+    Verify Time Delta    ATDome    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATDomeTrajectory
 Verify ATDomeTrajectory Disabled
@@ -46,7 +46,7 @@ Verify ATDomeTrajectory Disabled
 
 Verify ATDomeTrajectory SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATDomeTrajectory    command_start    logevent_summaryState
+    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATDomeTrajectory ConfigurationApplied Event
     [Tags]    config_applied
@@ -54,7 +54,7 @@ Verify ATDomeTrajectory ConfigurationApplied Event
 
 Verify ATDomeTrajectory ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATDomeTrajectory    command_start    logevent_configurationApplied
+    Verify Time Delta    ATDomeTrajectory    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATHexapod
 Verify ATHexapod Disabled
@@ -63,7 +63,7 @@ Verify ATHexapod Disabled
 
 Verify ATHexapod SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATHexapod    command_start    logevent_summaryState
+    Verify Time Delta    ATHexapod    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATHexapod ConfigurationApplied Event
     [Tags]    config_applied
@@ -71,7 +71,7 @@ Verify ATHexapod ConfigurationApplied Event
 
 Verify ATHexapod ConfigurationApplied Event timing 
     [Tags]    config_applied    timing
-    Verify Time Delta    ATHexapod    command_start    logevent_configurationApplied
+    Verify Time Delta    ATHexapod    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATMCS
 Verify ATMCS Disabled
@@ -80,7 +80,7 @@ Verify ATMCS Disabled
 
 Verify ATMCS SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMCS    command_start    logevent_summaryState
+    Verify Time Delta    ATMCS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ATMCS ConfigurationApplied Event
     [Tags]    config_applied    DM-44733
@@ -88,7 +88,7 @@ Verify ATMCS ConfigurationApplied Event
 
 Verify ATMCS ConfigurationApplied Event timing
     [Tags]    config_applied    timing    DM-44733
-    Verify Time Delta    ATMCS    command_start    logevent_configurationApplied
+    Verify Time Delta    ATMCS    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATPneumatics
 Verify ATPneumatics Disabled
@@ -97,7 +97,7 @@ Verify ATPneumatics Disabled
 
 Verify ATPneumatics SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATPneumatics    command_start    logevent_summaryState
+    Verify Time Delta    ATPneumatics    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ATPneumatics ConfigurationApplied Event
     [Tags]    config_applied    DM-44734
@@ -105,7 +105,7 @@ Verify ATPneumatics ConfigurationApplied Event
 
 Verify ATPneumatics ConfigurationApplied Event timing
     [Tags]    config_applied    timing    DM-44734
-    Verify Time Delta    ATPneumatics    command_start    logevent_configurationApplied
+    Verify Time Delta    ATPneumatics    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATPtg
 Verify ATPtg Disabled
@@ -114,7 +114,7 @@ Verify ATPtg Disabled
 
 Verify ATPtg SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATPtg    command_start    logevent_summaryState
+    Verify Time Delta    ATPtg    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ATPtg ConfigurationApplied Event
     [Tags]    config_applied

--- a/Disabled/Verify_AT_Light_Cal_Disabled.robot
+++ b/Disabled/Verify_AT_Light_Cal_Disabled.robot
@@ -12,7 +12,7 @@ Verify ATMonochromator Disabled
 
 Verify ATMonochromator SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMonochromator    command_start    logevent_summaryState
+    Verify Time Delta    ATMonochromator    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATMonochromator ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify ATMonochromator ConfigurationApplied Event
 
 Verify ATMonochromator ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATMonochromator    command_start    logevent_configurationApplied
+    Verify Time Delta    ATMonochromator    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #FiberSpectrograph:3
 Verify FiberSpectrograph:3 Disabled
@@ -29,7 +29,7 @@ Verify FiberSpectrograph:3 Disabled
 
 Verify FiberSpectrograph:3 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    FiberSpectrograph    command_start    logevent_summaryState    index=3
+    Verify Time Delta    FiberSpectrograph:3    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify FiberSpectrograph:3 ConfigurationApplied Event
     [Tags]    config_applied
@@ -37,4 +37,4 @@ Verify FiberSpectrograph:3 ConfigurationApplied Event
 
 Verify FiberSpectrograph:3 ConfigurationApplied timing
     [Tags]    config_applied    timing
-    Verify Time Delta    FiberSpectrograph    command_start    logevent_configurationApplied    index=3
+    Verify Time Delta    FiberSpectrograph:3    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Disabled/Verify_BigCamera_Disabled.robot
+++ b/Disabled/Verify_BigCamera_Disabled.robot
@@ -15,7 +15,7 @@ Verify BigCamera Disabled
 Verify BigCamera SummaryState timing
     [Tags]    software_versions    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    command_start    logevent_summaryState
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify BigCamera ConfigurationApplied Event
     [Tags]    config_applied
@@ -25,7 +25,7 @@ Verify BigCamera ConfigurationApplied Event
 Verify BigCamera ConfigurationApplied timing
     [Tags]    config_applied    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    command_start    logevent_configurationApplied
+    Verify Time Delta    ${BigCamera}    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OODS
 Verify OODS Disabled
@@ -36,7 +36,7 @@ Verify OODS Disabled
 Verify OODS SummaryState timing
     [Tags]    software_versions    timing
     Set Tags    ${OODS}
-    Verify Time Delta    ${OODS}    command_start    logevent_summaryState
+    Verify Time Delta    ${OODS}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify OODS ConfigurationApplied Event
     [Tags]    config_applied
@@ -46,7 +46,7 @@ Verify OODS ConfigurationApplied Event
 Verify OODS ConfigurationApplied timing
     [Tags]    config_applied    timing
     Set Tags    ${OODS}
-    Verify Time Delta    ${OODS}    command_start    logevent_configurationApplied
+    Verify Time Delta    ${OODS}    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #HeaderService
 Verify HeaderService Disabled
@@ -57,7 +57,7 @@ Verify HeaderService Disabled
 Verify HeaderService SummaryState timing
     [Tags]    software_versions    timing
     Set Tags    ${HeaderService}
-    Verify Time Delta    ${HeaderService}    command_start    logevent_summaryState
+    Verify Time Delta    ${HeaderService}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify HeaderService ConfigurationApplied Event
     [Tags]    config_applied
@@ -67,7 +67,7 @@ Verify HeaderService ConfigurationApplied Event
 Verify HeaderService ConfigurationApplied timing
     [Tags]    config_applied    timing
     Set Tags    ${HeaderService}
-    Verify Time Delta    ${HeaderService}    command_start    logevent_configurationApplied
+    Verify Time Delta    ${HeaderService}    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OCPS:2||3
 Verify OCPS:2||3 Disabled
@@ -78,7 +78,7 @@ Verify OCPS:2||3 Disabled
 Verify OCPS:2||3 SummaryState timing
     [Tags]    software_versions    timing
     Set Tags    OCPS:${OcpsIndex}
-    Verify Time Delta    OCPS    command_start    logevent_summaryState    index=${OcpsIndex}
+    Verify Time Delta    OCPS:${OcpsIndex}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify OCPS:2||3 ConfigurationApplied Event
     [Tags]    config_applied
@@ -88,4 +88,4 @@ Verify OCPS:2||3 ConfigurationApplied Event
 Verify OCPS:2||3 ConfigurationApplied timing
     [Tags]    config_applied    timing
     Set Tags    OCPS:${OcpsIndex}
-    Verify Time Delta    OCPS    command_start    logevent_configurationApplied    index=${OcpsIndex}
+    Verify Time Delta    OCPS:${OcpsIndex}    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Disabled/Verify_EAS_Disabled.robot
+++ b/Disabled/Verify_EAS_Disabled.robot
@@ -37,7 +37,7 @@ Verify DIMM:2 ConfigurationApplied Event
 
 Verify DIMM:2 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM    l:2ogevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    DIMM    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # EPM:1
 Verify EPM:1 Disabled

--- a/Disabled/Verify_EAS_Disabled.robot
+++ b/Disabled/Verify_EAS_Disabled.robot
@@ -12,7 +12,7 @@ Verify DIMM:1 Disabled
 
 Verify DIMM:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM    command_start    logevent_summaryState    index=1
+    Verify Time Delta    DIMM:1    logevent_summaryState    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DIMM:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify DIMM:1 ConfigurationApplied Event
 
 Verify DIMM:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    DIMM:1    logevent_configurationApplied    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # DIMM:2
 Verify DIMM:2 Disabled
@@ -29,7 +29,7 @@ Verify DIMM:2 Disabled
 
 Verify DIMM:2 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM    command_start    logevent_summaryState    index=2
+    Verify Time Delta    DIMM:2    logevent_summaryState    index=2    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DIMM:2 ConfigurationApplied Event
     [Tags]    config_applied
@@ -37,7 +37,7 @@ Verify DIMM:2 ConfigurationApplied Event
 
 Verify DIMM:2 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM    command_start    logevent_configurationApplied    index=2
+    Verify Time Delta    DIMM    l:2ogevent_configurationApplied    index=2    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # EPM:1
 Verify EPM:1 Disabled
@@ -46,7 +46,7 @@ Verify EPM:1 Disabled
 
 Verify EPM:1 SummaryState timing
     [Tags]    epm:1    software_versions    timing
-    Verify Time Delta    EPM    command_start    logevent_summaryState    index=1
+    Verify Time Delta    EPM:1    logevent_summaryState    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify EPM:1 ConfigurationApplied Event
     [Tags]    epm:1    config_applied
@@ -54,7 +54,7 @@ Verify EPM:1 ConfigurationApplied Event
 
 Verify EPM:1 ConfigurationApplied Event timing
     [Tags]    epm:1    config_applied    timing
-    Verify Time Delta    EPM    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    EPM:1    logevent_configurationApplied    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:1
 Verify ESS:1 Disabled
@@ -63,7 +63,7 @@ Verify ESS:1 Disabled
 
 Verify ESS:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=1
+    Verify Time Delta    ESS:1    logevent_summaryState    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -71,7 +71,7 @@ Verify ESS:1 ConfigurationApplied Event
 
 Verify ESS:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied   index=1
+    Verify Time Delta    ESS:1    logevent_configurationApplied   index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:101
 Verify ESS:101 Disabled
@@ -80,7 +80,7 @@ Verify ESS:101 Disabled
 
 Verify ESS:101 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=101
+    Verify Time Delta    ESS:101    logevent_summaryState    index=101    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:101 ConfigurationApplied Event
     [Tags]    config_applied
@@ -88,7 +88,7 @@ Verify ESS:101 ConfigurationApplied Event
 
 Verify ESS:101 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=101
+    Verify Time Delta    ESS:101    logevent_configurationApplied    index=101    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:102
 Verify ESS:102 Disabled
@@ -97,7 +97,7 @@ Verify ESS:102 Disabled
 
 Verify ESS:102 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=102
+    Verify Time Delta    ESS:102    logevent_summaryState    index=102    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:102 ConfigurationApplied Event
     [Tags]    config_applied
@@ -105,7 +105,7 @@ Verify ESS:102 ConfigurationApplied Event
 
 Verify ESS:102 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=102
+    Verify Time Delta    ESS:102    logevent_configurationApplied    index=102    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:103
 Verify ESS:103 Disabled
@@ -114,7 +114,7 @@ Verify ESS:103 Disabled
 
 Verify ESS:103 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=103
+    Verify Time Delta    ESS:103    logevent_summaryState    index=103    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:103 ConfigurationApplied Event
     [Tags]    config_applied
@@ -122,7 +122,7 @@ Verify ESS:103 ConfigurationApplied Event
 
 Verify ESS:103 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=103
+    Verify Time Delta    ESS:103    logevent_configurationApplied    index=103    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:104
 Verify ESS:104 Disabled
@@ -131,7 +131,7 @@ Verify ESS:104 Disabled
 
 Verify ESS:104 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=104
+    Verify Time Delta    ESS:104    logevent_summaryState    index=104    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:104 ConfigurationApplied Event
     [Tags]    config_applied
@@ -139,7 +139,7 @@ Verify ESS:104 ConfigurationApplied Event
 
 Verify ESS:104 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=104
+    Verify Time Delta    ESS:104    logevent_configurationApplied    index=104    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:105
 Verify ESS:105 Disabled
@@ -148,7 +148,7 @@ Verify ESS:105 Disabled
  
 Verify ESS:105 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=105
+    Verify Time Delta    ESS:105    logevent_summaryState    index=105    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:105 ConfigurationApplied Event
     [Tags]    config_applied
@@ -156,7 +156,7 @@ Verify ESS:105 ConfigurationApplied Event
     
 Verify ESS:105 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=105
+    Verify Time Delta    ESS:105    logevent_configurationApplied    index=105    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:106
 Verify ESS:106 Disabled
@@ -165,7 +165,7 @@ Verify ESS:106 Disabled
    
 Verify ESS:106 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=106
+    Verify Time Delta    ESS:106    logevent_summaryState    index=106    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:106 ConfigurationApplied Event
     [Tags]    config_applied
@@ -173,7 +173,7 @@ Verify ESS:106 ConfigurationApplied Event
     
 Verify ESS:106 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=106
+    Verify Time Delta    ESS:106    logevent_configurationApplied    index=106    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:107
 Verify ESS:107 Disabled
@@ -182,7 +182,7 @@ Verify ESS:107 Disabled
     
 Verify ESS:107 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=107
+    Verify Time Delta    ESS:107    logevent_summaryState    index=107    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ESS:107 ConfigurationApplied Event
     [Tags]    config_applied
@@ -190,7 +190,7 @@ Verify ESS:107 ConfigurationApplied Event
     
 Verify ESS:107 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=107
+    Verify Time Delta    ESS:107    logevent_configurationApplied    index=107    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:108
 Verify ESS:108 Disabled
@@ -199,7 +199,7 @@ Verify ESS:108 Disabled
     
 Verify ESS:108 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=108
+    Verify Time Delta    ESS:108    logevent_summaryState    index=108    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ESS:108 ConfigurationApplied Event
     [Tags]    config_applied
@@ -207,7 +207,7 @@ Verify ESS:108 ConfigurationApplied Event
     
 Verify ESS:108 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=108
+    Verify Time Delta    ESS:108    logevent_configurationApplied    index=108    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:201
 Verify ESS:201 Disabled
@@ -216,7 +216,7 @@ Verify ESS:201 Disabled
 
 Verify ESS:201 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=201
+    Verify Time Delta    ESS:201    logevent_summaryState    index=201    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:201 ConfigurationApplied Event
     [Tags]    config_applied
@@ -224,7 +224,7 @@ Verify ESS:201 ConfigurationApplied Event
 
 Verify ESS:201 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=201
+    Verify Time Delta    ESS:201    logevent_configurationApplied    index=201    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:202
 Verify ESS:202 Disabled
@@ -233,7 +233,7 @@ Verify ESS:202 Disabled
 
 Verify ESS:202 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=202
+    Verify Time Delta    ESS:202    logevent_summaryState    index=202    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:202 ConfigurationApplied Event
     [Tags]    config_applied
@@ -241,7 +241,7 @@ Verify ESS:202 ConfigurationApplied Event
 
 Verify ESS:202 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=202
+    Verify Time Delta    ESS:202    logevent_configurationApplied    index=202    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:203
 Verify ESS:203 Disabled
@@ -250,7 +250,7 @@ Verify ESS:203 Disabled
 
 Verify ESS:203 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=203
+    Verify Time Delta    ESS:203    logevent_summaryState    index=203    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:203 ConfigurationApplied Event
     [Tags]    config_applied
@@ -258,7 +258,7 @@ Verify ESS:203 ConfigurationApplied Event
 
 Verify ESS:203 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=203
+    Verify Time Delta    ESS:203    logevent_configurationApplied    index=203    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:204
 Verify ESS:204 Disabled
@@ -267,7 +267,7 @@ Verify ESS:204 Disabled
 
 Verify ESS:204 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=204
+    Verify Time Delta    ESS:204    logevent_summaryState    index=204    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:204 ConfigurationApplied Event
     [Tags]    config_applied
@@ -275,7 +275,7 @@ Verify ESS:204 ConfigurationApplied Event
 
 Verify ESS:204 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=204
+    Verify Time Delta    ESS:204    logevent_configurationApplied    index=204    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:205
 Verify ESS:205 Disabled
@@ -284,7 +284,7 @@ Verify ESS:205 Disabled
     
 Verify ESS:205 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=205
+    Verify Time Delta    ESS:205    logevent_summaryState    index=205    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:205 ConfigurationApplied Event
     [Tags]    config_applied
@@ -292,7 +292,7 @@ Verify ESS:205 ConfigurationApplied Event
 
 Verify ESS:205 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=205
+    Verify Time Delta    ESS:205    logevent_configurationApplied    index=205    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:301
 Verify ESS:301 Disabled
@@ -301,7 +301,7 @@ Verify ESS:301 Disabled
 
 Verify ESS:301 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    command_start    logevent_summaryState    index=301
+    Verify Time Delta    ESS:301    logevent_summaryState    index=301    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:301 ConfigurationApplied Event
     [Tags]    config_applied
@@ -309,4 +309,4 @@ Verify ESS:301 ConfigurationApplied Event
 
 Verify ESS:301 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS    command_start    logevent_configurationApplied    index=301
+    Verify Time Delta    ESS:301    logevent_configurationApplied    index=301    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Disabled/Verify_EAS_Disabled.robot
+++ b/Disabled/Verify_EAS_Disabled.robot
@@ -12,7 +12,7 @@ Verify DIMM:1 Disabled
 
 Verify DIMM:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM:1    logevent_summaryState    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    DIMM:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DIMM:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify DIMM:1 ConfigurationApplied Event
 
 Verify DIMM:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM:1    logevent_configurationApplied    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    DIMM:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # DIMM:2
 Verify DIMM:2 Disabled
@@ -29,7 +29,7 @@ Verify DIMM:2 Disabled
 
 Verify DIMM:2 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM:2    logevent_summaryState    index=2    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    DIMM:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DIMM:2 ConfigurationApplied Event
     [Tags]    config_applied
@@ -37,7 +37,7 @@ Verify DIMM:2 ConfigurationApplied Event
 
 Verify DIMM:2 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    DIMM    l:2ogevent_configurationApplied    index=2    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    DIMM    l:2ogevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # EPM:1
 Verify EPM:1 Disabled
@@ -46,7 +46,7 @@ Verify EPM:1 Disabled
 
 Verify EPM:1 SummaryState timing
     [Tags]    epm:1    software_versions    timing
-    Verify Time Delta    EPM:1    logevent_summaryState    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    EPM:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify EPM:1 ConfigurationApplied Event
     [Tags]    epm:1    config_applied
@@ -54,7 +54,7 @@ Verify EPM:1 ConfigurationApplied Event
 
 Verify EPM:1 ConfigurationApplied Event timing
     [Tags]    epm:1    config_applied    timing
-    Verify Time Delta    EPM:1    logevent_configurationApplied    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    EPM:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:1
 Verify ESS:1 Disabled
@@ -63,7 +63,7 @@ Verify ESS:1 Disabled
 
 Verify ESS:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:1    logevent_summaryState    index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -71,7 +71,7 @@ Verify ESS:1 ConfigurationApplied Event
 
 Verify ESS:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:1    logevent_configurationApplied   index=1    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:1    logevent_configurationApplied   hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:101
 Verify ESS:101 Disabled
@@ -80,7 +80,7 @@ Verify ESS:101 Disabled
 
 Verify ESS:101 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:101    logevent_summaryState    index=101    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:101    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:101 ConfigurationApplied Event
     [Tags]    config_applied
@@ -88,7 +88,7 @@ Verify ESS:101 ConfigurationApplied Event
 
 Verify ESS:101 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:101    logevent_configurationApplied    index=101    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:101    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:102
 Verify ESS:102 Disabled
@@ -97,7 +97,7 @@ Verify ESS:102 Disabled
 
 Verify ESS:102 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:102    logevent_summaryState    index=102    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:102    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:102 ConfigurationApplied Event
     [Tags]    config_applied
@@ -105,7 +105,7 @@ Verify ESS:102 ConfigurationApplied Event
 
 Verify ESS:102 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:102    logevent_configurationApplied    index=102    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:102    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:103
 Verify ESS:103 Disabled
@@ -114,7 +114,7 @@ Verify ESS:103 Disabled
 
 Verify ESS:103 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:103    logevent_summaryState    index=103    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:103    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:103 ConfigurationApplied Event
     [Tags]    config_applied
@@ -122,7 +122,7 @@ Verify ESS:103 ConfigurationApplied Event
 
 Verify ESS:103 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:103    logevent_configurationApplied    index=103    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:103    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:104
 Verify ESS:104 Disabled
@@ -131,7 +131,7 @@ Verify ESS:104 Disabled
 
 Verify ESS:104 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:104    logevent_summaryState    index=104    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:104    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:104 ConfigurationApplied Event
     [Tags]    config_applied
@@ -139,7 +139,7 @@ Verify ESS:104 ConfigurationApplied Event
 
 Verify ESS:104 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:104    logevent_configurationApplied    index=104    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:104    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:105
 Verify ESS:105 Disabled
@@ -148,7 +148,7 @@ Verify ESS:105 Disabled
  
 Verify ESS:105 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:105    logevent_summaryState    index=105    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:105    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:105 ConfigurationApplied Event
     [Tags]    config_applied
@@ -156,7 +156,7 @@ Verify ESS:105 ConfigurationApplied Event
     
 Verify ESS:105 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:105    logevent_configurationApplied    index=105    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:105    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:106
 Verify ESS:106 Disabled
@@ -165,7 +165,7 @@ Verify ESS:106 Disabled
    
 Verify ESS:106 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:106    logevent_summaryState    index=106    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:106    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:106 ConfigurationApplied Event
     [Tags]    config_applied
@@ -173,7 +173,7 @@ Verify ESS:106 ConfigurationApplied Event
     
 Verify ESS:106 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:106    logevent_configurationApplied    index=106    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:106    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:107
 Verify ESS:107 Disabled
@@ -182,7 +182,7 @@ Verify ESS:107 Disabled
     
 Verify ESS:107 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:107    logevent_summaryState    index=107    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:107    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ESS:107 ConfigurationApplied Event
     [Tags]    config_applied
@@ -190,7 +190,7 @@ Verify ESS:107 ConfigurationApplied Event
     
 Verify ESS:107 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:107    logevent_configurationApplied    index=107    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:107    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:108
 Verify ESS:108 Disabled
@@ -199,7 +199,7 @@ Verify ESS:108 Disabled
     
 Verify ESS:108 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:108    logevent_summaryState    index=108    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:108    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ESS:108 ConfigurationApplied Event
     [Tags]    config_applied
@@ -207,7 +207,7 @@ Verify ESS:108 ConfigurationApplied Event
     
 Verify ESS:108 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:108    logevent_configurationApplied    index=108    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:108    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:201
 Verify ESS:201 Disabled
@@ -216,7 +216,7 @@ Verify ESS:201 Disabled
 
 Verify ESS:201 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:201    logevent_summaryState    index=201    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:201    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:201 ConfigurationApplied Event
     [Tags]    config_applied
@@ -224,7 +224,7 @@ Verify ESS:201 ConfigurationApplied Event
 
 Verify ESS:201 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:201    logevent_configurationApplied    index=201    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:201    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:202
 Verify ESS:202 Disabled
@@ -233,7 +233,7 @@ Verify ESS:202 Disabled
 
 Verify ESS:202 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:202    logevent_summaryState    index=202    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:202    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:202 ConfigurationApplied Event
     [Tags]    config_applied
@@ -241,7 +241,7 @@ Verify ESS:202 ConfigurationApplied Event
 
 Verify ESS:202 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:202    logevent_configurationApplied    index=202    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:202    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:203
 Verify ESS:203 Disabled
@@ -250,7 +250,7 @@ Verify ESS:203 Disabled
 
 Verify ESS:203 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:203    logevent_summaryState    index=203    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:203    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:203 ConfigurationApplied Event
     [Tags]    config_applied
@@ -258,7 +258,7 @@ Verify ESS:203 ConfigurationApplied Event
 
 Verify ESS:203 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:203    logevent_configurationApplied    index=203    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:203    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:204
 Verify ESS:204 Disabled
@@ -267,7 +267,7 @@ Verify ESS:204 Disabled
 
 Verify ESS:204 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:204    logevent_summaryState    index=204    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:204    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:204 ConfigurationApplied Event
     [Tags]    config_applied
@@ -275,7 +275,7 @@ Verify ESS:204 ConfigurationApplied Event
 
 Verify ESS:204 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:204    logevent_configurationApplied    index=204    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:204    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:205
 Verify ESS:205 Disabled
@@ -284,7 +284,7 @@ Verify ESS:205 Disabled
     
 Verify ESS:205 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:205    logevent_summaryState    index=205    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:205    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:205 ConfigurationApplied Event
     [Tags]    config_applied
@@ -292,7 +292,7 @@ Verify ESS:205 ConfigurationApplied Event
 
 Verify ESS:205 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:205    logevent_configurationApplied    index=205    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:205    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:301
 Verify ESS:301 Disabled
@@ -301,7 +301,7 @@ Verify ESS:301 Disabled
 
 Verify ESS:301 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS:301    logevent_summaryState    index=301    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:301    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:301 ConfigurationApplied Event
     [Tags]    config_applied
@@ -309,4 +309,4 @@ Verify ESS:301 ConfigurationApplied Event
 
 Verify ESS:301 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ESS:301    logevent_configurationApplied    index=301    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
+    Verify Time Delta    ESS:301    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Disabled/Verify_GC_Disabled.robot
+++ b/Disabled/Verify_GC_Disabled.robot
@@ -12,7 +12,7 @@ Verify GenericCamera:1 Disabled
 
 Verify GenericCamera:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    GenericCamera    command_start    logevent_summaryState    index=1
+    Verify Time Delta    GenericCamera:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify GenericCamera:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify GenericCamera:1 ConfigurationApplied Event
 
 Verify GenericCamera:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    GenericCamera    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    GenericCamera:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #GCHeaderService:1
 Verify GCHeaderService:1 Disabled
@@ -29,7 +29,7 @@ Verify GCHeaderService:1 Disabled
 
 Verify GCHeaderService:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    GCHeaderService    command_start    logevent_summaryState    index=1
+    Verify Time Delta    GCHeaderService:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify GCHeaderService:1 ConfigurationApplied Event
     [Tags]    config_applied

--- a/Disabled/Verify_LATISS_Disabled.robot
+++ b/Disabled/Verify_LATISS_Disabled.robot
@@ -12,7 +12,7 @@ Verify ATCamera Disabled
 
 Verify ATCamera SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATCamera    command_start    logevent_summaryState
+    Verify Time Delta    ATCamera    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATCamera ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify ATCamera ConfigurationApplied Event
 
 Verify ATCamera ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATCamera    command_start    logevent_configurationApplied
+    Verify Time Delta    ATCamera    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATHeaderService
 Verify ATHeaderService Disabled
@@ -29,7 +29,7 @@ Verify ATHeaderService Disabled
 
 Verify ATHeaderService SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATHeaderService    command_start    logevent_summaryState
+    Verify Time Delta    ATHeaderService    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATHeaderService ConfigurationApplied Event
     [Tags]    config_applied
@@ -43,7 +43,7 @@ Verify OCPS:1 Disabled
 
 Verify OCPS:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    OCPS    command_start    logevent_summaryState    index=1
+    Verify Time Delta    OCPS:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify OCPS:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -51,7 +51,7 @@ Verify OCPS:1 ConfigurationApplied Event
 
 Verify OCPS:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    OCPS    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    OCPS:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATOODS
 Verify ATOODS Disabled
@@ -60,7 +60,7 @@ Verify ATOODS Disabled
 
 Verify ATOODS SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATOODS    command_start    logevent_summaryState
+    Verify Time Delta    ATOODS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATOODS ConfigurationApplied Event
     [Tags]    config_applied
@@ -74,7 +74,7 @@ Verify ATSpectrograph Disabled
 
 Verify ATSpectrograph SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATSpectrograph    command_start    logevent_summaryState
+    Verify Time Delta    ATSpectrograph    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATSpectrograph ConfigurationApplied Event
     [Tags]    config_applied
@@ -82,4 +82,4 @@ Verify ATSpectrograph ConfigurationApplied Event
 
 Verify ATSpectrograph ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    ATSpectrograph    command_start    logevent_configurationApplied
+    Verify Time Delta    ATSpectrograph    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Disabled/Verify_MTCS_Disabled.robot
+++ b/Disabled/Verify_MTCS_Disabled.robot
@@ -12,7 +12,7 @@ Verify LaserTracker:1 Disabled
 
 Verify LaserTracker:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    LaserTracker    command_start    logevent_summaryState    index=1
+    Verify Time Delta    LaserTracker:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify LaserTracker:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify LaserTracker:1 ConfigurationApplied Event
 
 Verify LaserTracker:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    LaserTracker    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    LaserTracker:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAirCompressor:1
 ##Auto-Enabled: no timing tests
@@ -49,7 +49,7 @@ Verify MTMount Disabled
 
 Verify MTMount SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTMount    command_start    logevent_summaryState
+    Verify Time Delta    MTMount    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTMount ConfigurationApplied Event 
     [Tags]    config_applied
@@ -57,7 +57,7 @@ Verify MTMount ConfigurationApplied Event
 
 Verify MTMount ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTMount    command_start    logevent_configurationApplied 
+    Verify Time Delta    MTMount    logevent_configurationApplied     hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTPtg
 Verify MTPtg Disabled
@@ -66,7 +66,7 @@ Verify MTPtg Disabled
 
 Verify MTPtg SummaryState timing
     [Tags]    mtptg    software_versions    timing
-    Verify Time Delta    MTPtg    command_start    logevent_summaryState
+    Verify Time Delta    MTPtg    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTPtg ConfigurationApplied Event
     [Tags]    mtptg    config_applied
@@ -79,7 +79,7 @@ Verify MTDome Disabled
 
 Verify MTDome SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTDome    command_start    logevent_summaryState
+    Verify Time Delta    MTDome    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTDome ConfigurationApplied Event
     [Tags]    config_applied
@@ -87,7 +87,7 @@ Verify MTDome ConfigurationApplied Event
 
 Verify MTDome ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTDome    command_start    logevent_configurationApplied
+    Verify Time Delta    MTDome    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTDomeTrajectory
 Verify MTDomeTrajectory Disabled
@@ -96,7 +96,7 @@ Verify MTDomeTrajectory Disabled
 
 Verify MTDomeTrajectory SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTDomeTrajectory    command_start    logevent_summaryState
+    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTDomeTrajectory ConfigurationApplied Event
     [Tags]    config_applied
@@ -104,7 +104,7 @@ Verify MTDomeTrajectory ConfigurationApplied Event
 
 Verify MTDomeTrajectory ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTDomeTrajectory    command_start    logevent_configurationApplied
+    Verify Time Delta    MTDomeTrajectory    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAOS
 Verify MTAOS Disabled
@@ -113,7 +113,7 @@ Verify MTAOS Disabled
 
 Verify MTAOS SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAOS    command_start    logevent_summaryState
+    Verify Time Delta    MTAOS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTAOS ConfigurationApplied Event
     [Tags]    config_applied
@@ -121,7 +121,7 @@ Verify MTAOS ConfigurationApplied Event
 
 Verify MTAOS ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTAOS    command_start    logevent_configurationApplied
+    Verify Time Delta    MTAOS    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTHexapod:1
 Verify MTHexapod:1 Disabled
@@ -130,7 +130,7 @@ Verify MTHexapod:1 Disabled
 
 Verify MTHexapod:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTHexapod    command_start    logevent_summaryState    index=1
+    Verify Time Delta    MTHexapod:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTHexapod:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -138,7 +138,7 @@ Verify MTHexapod:1 ConfigurationApplied Event
 
 Verify MTHexapod:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTHexapod    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    MTHexapod:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTHexapod:2
 Verify MTHexapod:2 Disabled
@@ -147,7 +147,7 @@ Verify MTHexapod:2 Disabled
 
 Verify MTHexapod:2 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTHexapod    command_start    logevent_summaryState    index=2
+    Verify Time Delta    MTHexapod:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTHexapod:2 ConfigurationApplied Event
     [Tags]    config_applied
@@ -155,7 +155,7 @@ Verify MTHexapod:2 ConfigurationApplied Event
 
 Verify MTHexapod:2 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTHexapod    command_start    logevent_configurationApplied    index=2
+    Verify Time Delta    MTHexapod:2    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTRotator
 Verify MTRotator Disabled
@@ -164,7 +164,7 @@ Verify MTRotator Disabled
 
 Verify MTRotator SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTRotator    command_start    logevent_summaryState
+    Verify Time Delta    MTRotator    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTRotator ConfigurationApplied Event
     [Tags]    config_applied
@@ -172,7 +172,7 @@ Verify MTRotator ConfigurationApplied Event
 
 Verify MTRotator ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTRotator    command_start    logevent_configurationApplied
+    Verify Time Delta    MTRotator    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTM1M3
 Verify MTM1M3 Disabled
@@ -181,7 +181,7 @@ Verify MTM1M3 Disabled
 
 Verify MTM1M3 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTM1M3    command_start    logevent_summaryState
+    Verify Time Delta    MTM1M3    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTM1M3 ConfigurationApplied Event
     [Tags]    config_applied
@@ -189,7 +189,7 @@ Verify MTM1M3 ConfigurationApplied Event
 
 Verify MTM1M3 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTM1M3    command_start    logevent_configurationApplied
+    Verify Time Delta    MTM1M3    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTM2
 Verify MTM2 Disabled
@@ -198,7 +198,7 @@ Verify MTM2 Disabled
 
 Verify MTM2 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTM2    command_start    logevent_summaryState
+    Verify Time Delta    MTM2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTM2 ConfigurationApplied Event
     [Tags]    config_applied
@@ -206,4 +206,4 @@ Verify MTM2 ConfigurationApplied Event
 
 Verify MTM2 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    MTM2    command_start    logevent_configurationApplied
+    Verify Time Delta    MTM2    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Disabled/Verify_ObsSys_Disabled.robot
+++ b/Disabled/Verify_ObsSys_Disabled.robot
@@ -12,7 +12,7 @@ Verify Scheduler:1 Disabled
 
 Verify Scheduler:1 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Scheduler    command_start    logevent_summaryState    index=1
+    Verify Time Delta    Scheduler:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify Scheduler:1 ConfigurationApplied Event
     [Tags]    config_applied
@@ -20,7 +20,7 @@ Verify Scheduler:1 ConfigurationApplied Event
 
 Verify Scheduler:1 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Scheduler    command_start    logevent_configurationApplied    index=1
+    Verify Time Delta    Scheduler:1    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #Scheduler:2
 Verify Scheduler:2 Disabled
@@ -29,7 +29,7 @@ Verify Scheduler:2 Disabled
 
 Verify Scheduler:2 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Scheduler    command_start    logevent_summaryState    index=2
+    Verify Time Delta    Scheduler:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify Scheduler:2 ConfigurationApplied Event
     [Tags]    config_applied
@@ -37,7 +37,7 @@ Verify Scheduler:2 ConfigurationApplied Event
 
 Verify Scheduler:2 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Scheduler    command_start    logevent_configurationApplied    index=2
+    Verify Time Delta    Scheduler:2    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #Scheduler:3
 Verify Scheduler:3 Disabled
@@ -46,7 +46,7 @@ Verify Scheduler:3 Disabled
 
 Verify Scheduler:3 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Scheduler    command_start    logevent_summaryState    index=3
+    Verify Time Delta    Scheduler:3    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify Scheduler:3 ConfigurationApplied Event
     [Tags]    config_applied
@@ -54,7 +54,7 @@ Verify Scheduler:3 ConfigurationApplied Event
 
 Verify Scheduler:3 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Scheduler    command_start    logevent_configurationApplied    index=3
+    Verify Time Delta    Scheduler:3    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ScriptQueue:1
 ##Auto-Enabled: no timing tests
@@ -93,7 +93,7 @@ Verify Watcher Disabled
 
 Verify Watcher SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Watcher    command_start    logevent_summaryState
+    Verify Time Delta    Watcher    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify Watcher ConfigurationApplied Event
     [Tags]    config_applied
@@ -101,7 +101,7 @@ Verify Watcher ConfigurationApplied Event
 
 Verify Watcher ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Watcher    command_start    logevent_configurationApplied
+    Verify Time Delta    Watcher    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #Test:42
 Verify Test:42 Disabled
@@ -110,7 +110,7 @@ Verify Test:42 Disabled
 
 Verify Test:42 SummaryState timing
     [Tags]    software_versions    timing
-    Verify Time Delta    Test    command_start    logevent_summaryState    index=42
+    Verify Time Delta    Test:42    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify Test:42 ConfigurationApplied Event
     [Tags]    config_applied
@@ -118,4 +118,4 @@ Verify Test:42 ConfigurationApplied Event
 
 Verify Test:42 ConfigurationApplied Event timing
     [Tags]    config_applied    timing
-    Verify Time Delta    Test    command_start    logevent_configurationApplied    index=42
+    Verify Time Delta    Test:42    logevent_configurationApplied    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_ATCS_Enabled.robot
+++ b/Enabled/Verify_ATCS_Enabled.robot
@@ -14,7 +14,7 @@ Verify ATAOS Enabled
 
 Verify ATAOS SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATAOS    command_enable    logevent_summaryState
+    Verify Time Delta    ATAOS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATDome
 Verify ATDome Enabled
@@ -23,7 +23,7 @@ Verify ATDome Enabled
 
 Verify ATDome SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATDome    command_enable    logevent_summaryState
+    Verify Time Delta    ATDome    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATDomeTrajectory
 Verify ATDomeTrajectory Enabled
@@ -32,7 +32,7 @@ Verify ATDomeTrajectory Enabled
 
 Verify ATDomeTrajectory SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATDomeTrajectory    command_enable    logevent_summaryState
+    Verify Time Delta    ATDomeTrajectory    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATHexapod
 Verify ATHexapod Enabled
@@ -41,7 +41,7 @@ Verify ATHexapod Enabled
 
 Verify ATHexapod SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATHexapod    command_enable    logevent_summaryState
+    Verify Time Delta    ATHexapod    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATMCS
 Verify ATMCS Enabled
@@ -50,7 +50,7 @@ Verify ATMCS Enabled
 
 Verify ATMCS SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATMCS    command_enable    logevent_summaryState
+    Verify Time Delta    ATMCS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATPneumatics
 Verify ATPneumatics Enabled
@@ -59,7 +59,7 @@ Verify ATPneumatics Enabled
 
 Verify ATPneumatics SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATPneumatics    command_enable    logevent_summaryState
+    Verify Time Delta    ATPneumatics    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATPtg
 Verify ATPtg Enabled
@@ -68,4 +68,4 @@ Verify ATPtg Enabled
 
 Verify ATPtg SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATPtg    command_enable    logevent_summaryState
+    Verify Time Delta    ATPtg    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_AT_Light_Cal_Enabled.robot
+++ b/Enabled/Verify_AT_Light_Cal_Enabled.robot
@@ -15,7 +15,7 @@ Verify ATMonochromator Enabled
 
 Verify ATMonochromator SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATMonochromator    command_enable    logevent_summaryState
+    Verify Time Delta    ATMonochromator    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #FiberSpectrograph:3
 Verify FiberSpectrograph:3 Enabled
@@ -24,4 +24,4 @@ Verify FiberSpectrograph:3 Enabled
 
 Verify FiberSpectrograph:3 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    FiberSpectrograph    command_enable    logevent_summaryState    index=3
+    Verify Time Delta    FiberSpectrograph:3    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_BigCamera_Enabled.robot
+++ b/Enabled/Verify_BigCamera_Enabled.robot
@@ -17,7 +17,7 @@ Verify BigCamera Enabled
 Verify BigCamera SummaryState timing
     [Tags]    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    command_enable    logevent_summaryState
+    Verify Time Delta    ${BigCamera}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OODS
 Verify OODS Enabled
@@ -28,7 +28,7 @@ Verify OODS Enabled
 Verify OODS SummaryState timing
     [Tags]    timing
     Set Tags    ${OODS}
-    Verify Time Delta    ${OODS}    command_enable    logevent_summaryState
+    Verify Time Delta    ${OODS}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #HeaderService
 Verify HeaderService Enabled
@@ -39,7 +39,7 @@ Verify HeaderService Enabled
 Verify HeaderService SummaryState timing
     [Tags]    timing
     Set Tags    ${HeaderService}
-    Verify Time Delta    ${HeaderService}    command_enable    logevent_summaryState
+    Verify Time Delta    ${HeaderService}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OCPS:2||3
 Verify OCPS:2||3 Enabled
@@ -50,4 +50,4 @@ Verify OCPS:2||3 Enabled
 Verify OCPS SummaryState timing
     [Tags]    timing
     Set Tags    OCPS:${OcpsIndex}
-    Verify Time Delta    OCPS    command_enable    logevent_summaryState    index=${OcpsIndex}
+    Verify Time Delta    OCPS:${OcpsIndex}    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_EAS_Enabled.robot
+++ b/Enabled/Verify_EAS_Enabled.robot
@@ -14,7 +14,7 @@ Verify DIMM:1 Enabled
 
 Verify DIMM:1 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    DIMM    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    DIMM:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #DIMM:2
 Verify DIMM:2 Enabled
@@ -23,7 +23,7 @@ Verify DIMM:2 Enabled
 
 Verify DIMM:2 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    DIMM    command_enable    logevent_summaryState    index=2
+    Verify Time Delta    DIMM:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #EPM:1
 Verify EPM:1 Enabled
@@ -32,7 +32,7 @@ Verify EPM:1 Enabled
 
 Verify EPM:1 SummaryState timing
     [Tags]    epm:1    enabled    timing
-    Verify Time Delta    EPM    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    EPM:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ESS:1
 Verify ESS:1 Enabled
@@ -41,7 +41,7 @@ Verify ESS:1 Enabled
 
 Verify ESS:1 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    ESS:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:101
 Verify ESS:101 Enabled
@@ -50,7 +50,7 @@ Verify ESS:101 Enabled
 
 Verify ESS:101 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=101
+    Verify Time Delta    ESS:101    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:102
 Verify ESS:102 Enabled
@@ -59,7 +59,7 @@ Verify ESS:102 Enabled
 
 Verify ESS:102 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=102
+    Verify Time Delta    ESS:102    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:103
 Verify ESS:103 Enabled
@@ -68,7 +68,7 @@ Verify ESS:103 Enabled
 
 Verify ESS:103 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=103
+    Verify Time Delta    ESS:103    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:104
 Verify ESS:104 Enabled
@@ -77,7 +77,7 @@ Verify ESS:104 Enabled
 
 Verify ESS:104 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=104
+    Verify Time Delta    ESS:104    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:105
 Verify ESS:105 Enabled
@@ -86,7 +86,7 @@ Verify ESS:105 Enabled
 
 Verify ESS:105 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=105
+    Verify Time Delta    ESS:105    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:106
 Verify ESS:106 Enabled
@@ -95,7 +95,7 @@ Verify ESS:106 Enabled
 
 Verify ESS:106 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=106
+    Verify Time Delta    ESS:106    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:107
 Verify ESS:107 Enabled
@@ -104,7 +104,7 @@ Verify ESS:107 Enabled
 
 Verify ESS:107 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=107
+    Verify Time Delta    ESS:107    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:108
 Verify ESS:108 Enabled
@@ -113,7 +113,7 @@ Verify ESS:108 Enabled
 
 Verify ESS:108 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=108
+    Verify Time Delta    ESS:108    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:201
 Verify ESS:201 Enabled
@@ -122,7 +122,7 @@ Verify ESS:201 Enabled
 
 Verify ESS:201 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=201
+    Verify Time Delta    ESS:201    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:202
 Verify ESS:202 Enabled
@@ -131,7 +131,7 @@ Verify ESS:202 Enabled
 
 Verify ESS:202 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=202
+    Verify Time Delta    ESS:202    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:203
 Verify ESS:203 Enabled
@@ -140,7 +140,7 @@ Verify ESS:203 Enabled
 
 Verify ESS:203 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=203
+    Verify Time Delta    ESS:203    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:204
 Verify ESS:204 Enabled
@@ -149,7 +149,7 @@ Verify ESS:204 Enabled
 
 Verify ESS:204 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=204
+    Verify Time Delta    ESS:204    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:205
 Verify ESS:205 Enabled
@@ -158,7 +158,7 @@ Verify ESS:205 Enabled
 
 Verify ESS:205 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=205
+    Verify Time Delta    ESS:205    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ESS:301
 Verify ESS:301 Enabled
@@ -167,4 +167,4 @@ Verify ESS:301 Enabled
 
 Verify ESS:301 SummaryState timing
     [Tags]    enabled    timing
-    Verify Time Delta    ESS    command_enable    logevent_summaryState    index=301
+    Verify Time Delta    ESS:301    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_GC_Enabled.robot
+++ b/Enabled/Verify_GC_Enabled.robot
@@ -14,7 +14,7 @@ Verify GenericCamera:1 Enabled
 
 Verify GenericCamera:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    GenericCamera    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    GenericCamera:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # GCHeaderService:1
 Verify GCHeaderService:1 Enabled
@@ -23,4 +23,4 @@ Verify GCHeaderService:1 Enabled
 
 Verify GCHeaderService:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    GCHeaderService    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    GCHeaderService:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_LATISS_Enabled.robot
+++ b/Enabled/Verify_LATISS_Enabled.robot
@@ -14,7 +14,7 @@ Verify ATCamera Enabled
 
 Verify ATCamera SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATCamera    command_enable    logevent_summaryState
+    Verify Time Delta    ATCamera    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATHeaderService
 Verify ATHeaderService Enabled
@@ -23,7 +23,7 @@ Verify ATHeaderService Enabled
 
 Verify ATHeaderService SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATHeaderService    command_enable    logevent_summaryState
+    Verify Time Delta    ATHeaderService    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OCPS:1
 Verify OCPS:1 Enabled
@@ -32,7 +32,7 @@ Verify OCPS:1 Enabled
 
 Verify OCPS:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    OCPS    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    OCPS:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATOODS
 Verify ATOODS Enabled
@@ -41,7 +41,7 @@ Verify ATOODS Enabled
 
 Verify ATOODS SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATOODS    command_enable    logevent_summaryState
+    Verify Time Delta    ATOODS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATSpectrograph
 Verify ATSpectrograph Enabled
@@ -50,4 +50,4 @@ Verify ATSpectrograph Enabled
 
 Verify ATSpectrograph SummaryState timing
     [Tags]    timing
-    Verify Time Delta    ATSpectrograph    command_enable    logevent_summaryState
+    Verify Time Delta    ATSpectrograph    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_MTCS_Enabled.robot
+++ b/Enabled/Verify_MTCS_Enabled.robot
@@ -104,7 +104,7 @@ Verify MTRotator Enabled
 
 Verify MTRotator SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTRotator    logevent_summaryState
+    Verify Time Delta    MTRotator    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTM1M3
 Verify MTM1M3 Enabled
@@ -113,7 +113,7 @@ Verify MTM1M3 Enabled
 
 Verify MTM1M3 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTM1M3    logevent_summaryState
+    Verify Time Delta    MTM1M3    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTM2
 Verify MTM2 Enabled
@@ -122,4 +122,4 @@ Verify MTM2 Enabled
 
 Verify MTM2 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTM2    logevent_summaryState
+    Verify Time Delta    MTM2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_MTCS_Enabled.robot
+++ b/Enabled/Verify_MTCS_Enabled.robot
@@ -14,7 +14,7 @@ Verify LaserTracker:1 Enabled
 
 Verify LaserTracker:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    LaserTracker    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    LaserTracker:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAirCompressor:1
 Verify MTAirCompressor:1 Enabled
@@ -23,7 +23,7 @@ Verify MTAirCompressor:1 Enabled
 
 Verify MTAirCompressor:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTAirCompressor    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    MTAirCompressor:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAirCompressor:2
 Verify MTAirCompressor:2 Enabled
@@ -32,7 +32,7 @@ Verify MTAirCompressor:2 Enabled
 
 Verify MTAirCompressor:2 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTAirCompressor    command_enable    logevent_summaryState    index=2
+    Verify Time Delta    MTAirCompressor:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTMount
 Verify MTMount Enabled
@@ -41,7 +41,7 @@ Verify MTMount Enabled
 
 Verify MTMount SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTMount    command_enable    logevent_summaryState
+    Verify Time Delta    MTMount    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTPtg
 Verify MTPtg Enabled
@@ -50,7 +50,7 @@ Verify MTPtg Enabled
 
 Verify MTPtg SummaryState timing
     [Tags]    mtptg    timing
-    Verify Time Delta    MTPtg    command_enable    logevent_summaryState
+    Verify Time Delta    MTPtg    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTDome
 Verify MTDome Enabled
@@ -59,7 +59,7 @@ Verify MTDome Enabled
 
 Verify MTDome SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTDome    command_enable    logevent_summaryState
+    Verify Time Delta    MTDome    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTDomeTrajectory
 Verify MTDomeTrajectory Enabled
@@ -68,7 +68,7 @@ Verify MTDomeTrajectory Enabled
 
 Verify MTDomeTrajectory SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTDomeTrajectory    command_enable    logevent_summaryState
+    Verify Time Delta    MTDomeTrajectory    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAOS
 Verify MTAOS Enabled
@@ -77,7 +77,7 @@ Verify MTAOS Enabled
 
 Verify MTAOS SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTAOS    command_enable    logevent_summaryState
+    Verify Time Delta    MTAOS    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTHexapod:1
 Verify MTHexapod:1 Enabled
@@ -86,7 +86,7 @@ Verify MTHexapod:1 Enabled
 
 Verify MTHexapod:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTHexapod    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    MTHexapod:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTHexapod:2
 Verify MTHexapod:2 Enabled
@@ -95,7 +95,7 @@ Verify MTHexapod:2 Enabled
 
 Verify MTHexapod:2 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTHexapod    command_enable    logevent_summaryState    index=2
+    Verify Time Delta    MTHexapod:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTRotator
 Verify MTRotator Enabled
@@ -104,7 +104,7 @@ Verify MTRotator Enabled
 
 Verify MTRotator SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTRotator    command_enable    logevent_summaryState
+    Verify Time Delta    MTRotator    logevent_summaryState
 
 #MTM1M3
 Verify MTM1M3 Enabled
@@ -113,7 +113,7 @@ Verify MTM1M3 Enabled
 
 Verify MTM1M3 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTM1M3    command_enable    logevent_summaryState
+    Verify Time Delta    MTM1M3    logevent_summaryState
 
 #MTM2
 Verify MTM2 Enabled
@@ -122,4 +122,4 @@ Verify MTM2 Enabled
 
 Verify MTM2 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    MTM2    command_enable    logevent_summaryState
+    Verify Time Delta    MTM2    logevent_summaryState

--- a/Enabled/Verify_ObsSys_Enabled.robot
+++ b/Enabled/Verify_ObsSys_Enabled.robot
@@ -14,7 +14,7 @@ Verify Scheduler:1 Enabled
 
 Verify Scheduler:1 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    Scheduler    command_enable    logevent_summaryState    index=1
+    Verify Time Delta    Scheduler:1    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #Scheduler:2
 Verify Scheduler:2 Enabled
@@ -23,7 +23,7 @@ Verify Scheduler:2 Enabled
 
 Verify Scheduler:2 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    Scheduler    command_enable    logevent_summaryState    index=2
+    Verify Time Delta    Scheduler:2    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #Scheduler:3
 Verify Scheduler:3 Enabled
@@ -32,7 +32,7 @@ Verify Scheduler:3 Enabled
 
 Verify Scheduler:3 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    Scheduler    command_enable    logevent_summaryState    index=3
+    Verify Time Delta    Scheduler:3    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ScriptQueue:1
 Verify ScriptQueue:1 Enabled
@@ -56,7 +56,7 @@ Verify Watcher Enabled
 
 Verify Watcher SummaryState timing
     [Tags]    timing
-    Verify Time Delta    Watcher    command_enable    logevent_summaryState
+    Verify Time Delta    Watcher    logevent_summaryState
 
 #Test:42
 Verify Test:42 Enabled
@@ -65,4 +65,4 @@ Verify Test:42 Enabled
 
 Verify Test:42 SummaryState timing
     [Tags]    timing
-    Verify Time Delta    Test    command_enable    logevent_summaryState    index=42
+    Verify Time Delta    Test:42    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Enabled/Verify_ObsSys_Enabled.robot
+++ b/Enabled/Verify_ObsSys_Enabled.robot
@@ -56,7 +56,7 @@ Verify Watcher Enabled
 
 Verify Watcher SummaryState timing
     [Tags]    timing
-    Verify Time Delta    Watcher    logevent_summaryState
+    Verify Time Delta    Watcher    logevent_summaryState    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #Test:42
 Verify Test:42 Enabled

--- a/Offline/Verify_Cameras_Offline.robot
+++ b/Offline/Verify_Cameras_Offline.robot
@@ -21,7 +21,7 @@ Verify ATCamera SoftwareVersions
 
 Verify ATCamera SoftwareVersions timing
     [Tags]    latiss    software_versions    timing
-    Verify Time Delta    ATCamera    logevent_summaryState    logevent_softwareVersions
+    Verify Time Delta    ATCamera    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATCamera OfflineDetailedStates
     [Tags]    latiss    detailed_states
@@ -43,7 +43,7 @@ Verify ATCamera OfflineDetailedStates
 
 Verify ATCamera OfflineDetailedStates timing
     [Tags]    latiss    detailed_states    timing
-    Verify Time Delta    ATCamera    logevent_summaryState   ${offdet_topic}
+    Verify Time Delta    ATCamera    ${offdet_topic}    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #BigCamera
 Verify BigCamera Offline
@@ -59,7 +59,7 @@ Verify BigCamera SoftwareVersions
 Verify BigCamera SoftwareVersions timing
     [Tags]    software_versions    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    logevent_summaryState    logevent_softwareVersions
+    Verify Time Delta    ${BigCamera}    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify BigCamera OfflineDetailedStates
     [Tags]
@@ -83,4 +83,4 @@ Verify BigCamera OfflineDetailedStates
 Verify BigCamera OfflineDetailedStates timing
     [Tags]    detailed_states    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    ${offdet_topic}    logevent_summaryState
+    Verify Time Delta    ${BigCamera}    ${offdet_topic}    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Shutdown/Verify_ATCS_Shutdown.robot
+++ b/Shutdown/Verify_ATCS_Shutdown.robot
@@ -5,43 +5,32 @@ Resource    ../Common_Keywords.resource
 Force Tags    shutdown
 Suite Setup    Log Many    ${STATES}[offline]
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify ATAOS Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATAOS
-    Verify Time Delta    ATAOS    ${topic_1}    ${topic_2}
 
 Verify ATDome Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATDome
-    Verify Time Delta    ATDome    ${topic_1}    ${topic_2}
 
 Verify ATDomeTrajectory Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATDomeTrajectory
-    Verify Time Delta    ATDomeTrajectory    ${topic_1}    ${topic_2}
 
 Verify ATHexapod Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATHexapod
-    Verify Time Delta    ATHexapod    ${topic_1}    ${topic_2}
 
 Verify ATMCS Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATMCS
-    Verify Time Delta    ATMCS    ${topic_1}    ${topic_2}
 
 Verify ATPneumatics Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATPneumatics
-    Verify Time Delta    ATPneumatics    ${topic_1}    ${topic_2}
 
 Verify ATPtg Shutdown
     [Tags]    atcs
     Verify Shutdown Process    ATPtg
-    Verify Time Delta    ATPtg    ${topic_1}    ${topic_2}
 

--- a/Shutdown/Verify_AT_Light_Cal_Shutdown.robot
+++ b/Shutdown/Verify_AT_Light_Cal_Shutdown.robot
@@ -4,17 +4,11 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    shutdown    skipped
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify ATMonochromator Shutdown
     [Tags]    at_light_cal
     Verify Shutdown Process    ATMonochromator
-    Verify Time Delta    ATMonochromator    ${topic_1}    ${topic_2}
 
 Verify FiberSpectrograph:3 Shutdown
     [Tags]    at_light_cal
     Verify Shutdown Process    FiberSpectrograph    index=3
-    Verify Time Delta    FiberSpectrograph    ${topic_1}    ${topic_2}    index=3

--- a/Shutdown/Verify_BigCamera_Shutdown.robot
+++ b/Shutdown/Verify_BigCamera_Shutdown.robot
@@ -5,31 +5,23 @@ Resource    ../Common_Keywords.resource
 Force Tags    shutdown
 Suite Setup   Set EFD Values
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify BigCamera Shutdown
     [Tags]
     Set Tags    ${BigCamera}
     Verify Shutdown Process    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    ${topic_1}    ${topic_2}
 
 Verify OODS Shutdown
     [Tags]
     Set Tags    ${OODS}
     Verify Shutdown Process    ${OODS}
-    Verify Time Delta    ${OODS}    ${topic_1}    ${topic_2}
 
 Verify HeaderService Shutdown
     [Tags]
     Set Tags    ${HeaderService}
     Verify Shutdown Process    ${HeaderService}
-    Verify Time Delta    ${HeaderService}    ${topic_1}    ${topic_2}
 
 Verify OCPS:2||3 Shutdown
     [Tags]
     Set Tags    OCPS:${OcpsIndex}
     Verify Shutdown Process    OCPS    index=${OcpsIndex}
-    Verify Time Delta    OCPS    ${topic_1}    ${topic_2}    index=${OcpsIndex}

--- a/Shutdown/Verify_EAS_AE_Shutdown.robot
+++ b/Shutdown/Verify_EAS_AE_Shutdown.robot
@@ -4,22 +4,15 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    shutdown
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify DSM:1 Shutdown
     [Tags]    eas_ae
     Verify Shutdown Process    DSM    index=1
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=1
 
 Verify DSM:2 Shutdown
     [Tags]    eas_ae
     Verify Shutdown Process    DSM    index=2
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=2
 
 Verify WeatherForecast Shutdown
     [Tags]    eas
     Verify Shutdown Process    WeatherForecast
-    Verify Time Delta    WeatherForecast    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_EAS_Shutdown.robot
+++ b/Shutdown/Verify_EAS_Shutdown.robot
@@ -4,111 +4,87 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    shutdown
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 # DIMM
 Verify DIMM:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DIMM    index=1
-    Verify Time Delta    DIMM    ${topic_1}    ${topic_2}    index=1
 
 Verify DIMM:2 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DIMM    index=2
-    Verify Time Delta    DIMM    ${topic_1}    ${topic_2}    index=2
 
 #DSM
 Verify DSM:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DSM    index=1
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=1
 
 Verify DSM:2 Shutdown
     [Tags]    eas
     Verify Shutdown Process    DSM    index=2
-    Verify Time Delta    DSM    ${topic_1}    ${topic_2}    index=2
 
 # EPM:1
 Verify EPM:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    EPM    index=1
-    Verify Time Delta    EPM    ${topic_1}    ${topic_2}    index=1
 
 # ESS
 Verify ESS:1 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=1
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=1
 
 Verify ESS:101 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=101
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=101
 
 Verify ESS:102 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=102
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=102
 
 Verify ESS:103 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=103
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=103
 
 Verify ESS:104 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=104
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=104
 
 Verify ESS:105 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=105
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=105
 
 Verify ESS:106 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=106
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=106
 
 Verify ESS:107 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=107
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=107
 
 Verify ESS:108 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=108
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=108
 
 Verify ESS:201 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=201
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=201
 
 Verify ESS:202 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=202
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=202
 
 Verify ESS:203 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=203
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=203
 
 Verify ESS:204 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=204
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=204
 
 Verify ESS:205 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=205
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=205
 
 Verify ESS:301 Shutdown
     [Tags]    eas
     Verify Shutdown Process    ESS    index=301
-    Verify Time Delta    ESS    ${topic_1}    ${topic_2}    index=301

--- a/Shutdown/Verify_GC_Shutdown.robot
+++ b/Shutdown/Verify_GC_Shutdown.robot
@@ -4,17 +4,11 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    shutdown
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify GenericCamera:1 Shutdown
     [Tags]    gc
     Verify Shutdown Process    GenericCamera    index=1
-    Verify Time Delta    GenericCamera    ${topic_1}    ${topic_2}    index=1
 
 Verify GCHeaderService:1 Shutdown
     [Tags]    gc
     Verify Shutdown Process    GCHeaderService    index=1
-    Verify Time Delta    GCHeaderService    ${topic_1}    ${topic_2}    index=1

--- a/Shutdown/Verify_LATISS_Shutdown.robot
+++ b/Shutdown/Verify_LATISS_Shutdown.robot
@@ -4,32 +4,23 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    shutdown
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify ATCamera Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATCamera
-    Verify Time Delta    ATCamera    ${topic_1}    ${topic_2}
 
 Verify ATHeaderService Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATHeaderService
-    Verify Time Delta    ATHeaderService    ${topic_1}    ${topic_2}
 
 Verify OCPS:1 Shutdown
     [Tags]    obsys2
     Verify Shutdown Process    OCPS    index=1
-    Verify Time Delta    OCPS    ${topic_1}    ${topic_2}    index=1
 
 Verify ATOODS Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATOODS
-    Verify Time Delta    ATOODS    ${topic_1}    ${topic_2}
 
 Verify ATSpectrograph Shutdown
     [Tags]    latiss
     Verify Shutdown Process    ATSpectrograph
-    Verify Time Delta    ATSpectrograph    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_MTCS_Shutdown.robot
+++ b/Shutdown/Verify_MTCS_Shutdown.robot
@@ -4,72 +4,55 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    mtcs    shutdown
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify LaserTracker:1 Shutdown
     [Tags]
     Verify Shutdown Process    LaserTracker    index=1
-    Verify Time Delta    LaserTracker    ${topic_1}    ${topic_2}    index=1
 
 Verify MTAirCompressor:1 Shutdown
     [Tags]
     Verify Shutdown Process    MTAirCompressor    index=1
-    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    index=1
 
 Verify MTAirCompressor:2 Shutdown
     [Tags]
     Verify Shutdown Process    MTAirCompressor    index=2
-    Verify Time Delta    MTAirCompressor    ${topic_1}    ${topic_2}    index=2
 
 Verify MTMount Shutdown
     [Tags]
     Verify Shutdown Process    MTMount
-    Verify Time Delta    MTMount    ${topic_1}    ${topic_2}
 
 Verify MTPtg Shutdown
     [Tags]    mtptg
     Verify Shutdown Process    MTPtg
-    Verify Time Delta    MTPtg    ${topic_1}    ${topic_2}
 
 Verify MTDome Shutdown
     [Tags]
     Verify Shutdown Process    MTDome
-    Verify Time Delta    MTDome    ${topic_1}    ${topic_2}
 
 Verify MTDomeTrajectory Shutdown
     [Tags]
     Verify Shutdown Process    MTDomeTrajectory
-    Verify Time Delta    MTDomeTrajectory    ${topic_1}    ${topic_2}
 
 Verify MTAOS Shutdown
     [Tags]
     Verify Shutdown Process    MTAOS
-    Verify Time Delta    MTAOS    ${topic_1}    ${topic_2}
 
 Verify MTHexapod:1 Shutdown
     [Tags]
     Verify Shutdown Process    MTHexapod    index=1
-    Verify Time Delta    MTHexapod    ${topic_1}    ${topic_2}    index=1
 
 Verify MTHexapod:2 Shutdown
     [Tags]
     Verify Shutdown Process    MTHexapod    index=2
-    Verify Time Delta    MTHexapod    ${topic_1}    ${topic_2}    index=2
 
 Verify MTRotator Shutdown
     [Tags]
     Verify Shutdown Process    MTRotator
-    Verify Time Delta    MTRotator    ${topic_1}    ${topic_2}
 
 Verify MTM1M3 Shutdown
     [Tags]
     Verify Shutdown Process    MTM1M3
-    Verify Time Delta    MTM1M3    ${topic_1}    ${topic_2}
 
 Verify MTM2 Shutdown
     [Tags]
     Verify Shutdown Process    MTM2
-    Verify Time Delta    MTM2    ${topic_1}    ${topic_2}

--- a/Shutdown/Verify_ObsSys_Shutdown.robot
+++ b/Shutdown/Verify_ObsSys_Shutdown.robot
@@ -4,42 +4,31 @@ Resource    ../CSC_Lists.resource
 Resource    ../Common_Keywords.resource
 Force Tags    shutdown    obssys
 
-*** Variables ***
-${topic_1}    command_disable
-${topic_2}    logevent_summaryState
-
 *** Test Cases ***
 Verify Scheduler:1 Shutdown
     [Tags]
     Verify Shutdown Process    Scheduler    index=1
-    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    index=1
 
 Verify Scheduler:2 Shutdown
     [Tags]
     Verify Shutdown Process    Scheduler    index=2
-    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    index=2
 
 Verify Scheduler:3 Shutdown
     [Tags]
     Verify Shutdown Process    Scheduler    index=3
-    Verify Time Delta    Scheduler    ${topic_1}    ${topic_2}    index=3
 
 Verify ScriptQueue:1 Shutdown
     [Tags]
     Verify Shutdown Process    ScriptQueue    1
-    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    index=1
 
 Verify ScriptQueue:2 Shutdown
     [Tags]
     Verify Shutdown Process    ScriptQueue    index=2
-    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    index=2
 
 Verify ScriptQueue:3 Shutdown
     [Tags]
     Verify Shutdown Process    ScriptQueue    index=3
-    Verify Time Delta    ScriptQueue    ${topic_1}    ${topic_2}    index=3
 
 Verify Watcher Shutdown
     [Tags]
     Verify Shutdown Process    Watcher
-    Verify Time Delta    Watcher    ${topic_1}    ${topic_2}

--- a/Standby/Verify_ATCS_Standby.robot
+++ b/Standby/Verify_ATCS_Standby.robot
@@ -32,7 +32,7 @@ Verify ATAOS SoftwareVersions
 
 Verify ATAOS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATAOS    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATAOS    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATAOS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -40,7 +40,7 @@ Verify ATAOS ConfigurationsAvailable Event
 
 Verify ATAOS ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATAOS    logevent_configurationsAvailable
+    Verify Time Delta    ATAOS    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATDome
 Verify ATDome Standby
@@ -53,7 +53,7 @@ Verify ATDome SoftwareVersions
 
 Verify ATDome SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATDome    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATDome    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATDome ConfigurationsAvailable Event
     [Tags]    config_available
@@ -61,7 +61,7 @@ Verify ATDome ConfigurationsAvailable Event
 
 Verify ATDome ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATDome    logevent_configurationsAvailable
+    Verify Time Delta    ATDome    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATDomeTrajectory
 Verify ATDomeTrajectory Standby
@@ -74,7 +74,7 @@ Verify ATDomeTrajectory SoftwareVersions
 
 Verify ATDomeTrajectory SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATDomeTrajectory    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATDomeTrajectory    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATDomeTrajectory ConfigurationsAvailable Event
     [Tags]    config_available
@@ -82,7 +82,7 @@ Verify ATDomeTrajectory ConfigurationsAvailable Event
 
 Verify ATDomeTrajectory ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATDomeTrajectory    logevent_configurationsAvailable
+    Verify Time Delta    ATDomeTrajectory    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATHexapod
 Verify ATHexapod Standby
@@ -95,7 +95,7 @@ Verify ATHexapod SoftwareVersions
 
 Verify ATHexapod SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATHexapod    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATHexapod    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATHexapod ConfigurationsAvailable Event
     [Tags]    config_available
@@ -103,7 +103,7 @@ Verify ATHexapod ConfigurationsAvailable Event
 
 Verify ATHexapod ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATHexapod    logevent_configurationsAvailable
+    Verify Time Delta    ATHexapod    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATMCS
 Verify ATMCS Standby
@@ -115,8 +115,8 @@ Verify ATMCS SoftwareVersions
     Verify Software Versions    ATMCS    csc_salver=${atmcs_salver}    csc_xmlver=${atmcs_xmlver}
 
 Verify ATMCS SoftwareVersions timing
-    [Tags]    software_versions    timing
-    Verify Time Delta    ATMCS    logevent_softwareVersions    logevent_summaryState
+    [Tags]    software_versions    timing    DM-39357
+    Verify Time Delta    ATMCS    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATMCS ConfigurationsAvailable Event
     [Tags]    config_available    DM-44733
@@ -124,7 +124,7 @@ Verify ATMCS ConfigurationsAvailable Event
 
 Verify ATMCS ConfigurationsAvailable timing
     [Tags]    config_available    timing    DM-44733
-    Verify Time Delta    ATMCS    logevent_configurationsAvailable
+    Verify Time Delta    ATMCS    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATPneumatics
 Verify ATPneumatics Standby
@@ -137,15 +137,15 @@ Verify ATPneumatics SoftwareVersions
 
 Verify ATPneumatics SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATPneumatics    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATPneumatics    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATPneumatics ConfigurationsAvailable Event
     [Tags]    config_available    DM-44734
     Verify ConfigurationsAvailable    ATPneumatics
 
-Verify ATMCS ConfigurationsAvailable timing
+Verify ATPneumatics ConfigurationsAvailable timing
     [Tags]    config_available    timing    DM-44734
-    Verify Time Delta    ATMCS    logevent_configurationsAvailable
+    Verify Time Delta    ATMCS    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATPtg
 Verify ATPtg Standby
@@ -158,7 +158,7 @@ Verify ATPtg SoftwareVersions
 
 Verify ATPtg SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATPtg    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATPtg    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATPtg ConfigurationsAvailable Event
     [Tags]    config_available

--- a/Standby/Verify_AT_Light_Cal_Standby.robot
+++ b/Standby/Verify_AT_Light_Cal_Standby.robot
@@ -22,7 +22,7 @@ Verify ATMonochromator SoftwareVersions
 
 Verify ATMonochromator SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMonochromator    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATMonochromator    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATMonochromator ConfigurationsAvailable Event
     [Tags]    config_available
@@ -30,7 +30,7 @@ Verify ATMonochromator ConfigurationsAvailable Event
 
 Verify ATMonochromator ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATMonochromator    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    ATMonochromator    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #FiberSpectrograph:3
 Verify FiberSpectrograph:3 Standby
@@ -43,7 +43,7 @@ Verify FiberSpectrograph:3 SoftwareVersions
 
 Verify FiberSpectrograph:3 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATMonochromator    logevent_softwareVersions    logevent_summaryState    index=3
+    Verify Time Delta    ATMonochromator:3    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify FiberSpectrograph:3 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -51,4 +51,4 @@ Verify FiberSpectrograph:3 ConfigurationsAvailable Event
 
 Verify FiberSpectrograph:3 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    FiberSpectrograph    logevent_configurationsAvailable    logevent_summaryState    index=3
+    Verify Time Delta    FiberSpectrograph:3    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Standby/Verify_BigCamera_Standby.robot
+++ b/Standby/Verify_BigCamera_Standby.robot
@@ -38,7 +38,7 @@ Verify BigCamera SoftwareVersions Event
 Verify BigCamera SoftwareVersions Event timing
     [Tags]    software_versions    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ${BigCamera}    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify BigCamera ConfigurationsAvailable Event
     [Tags]    config_available
@@ -48,7 +48,7 @@ Verify BigCamera ConfigurationsAvailable Event
 Verify BigCamera ConfigurationsAvailable Event timing
     [Tags]    config_available    timing
     Set Tags    ${BigCamera}
-    Verify Time Delta    ${BigCamera}    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    ${BigCamera}    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OODS
 Verify OODS Standby
@@ -64,7 +64,7 @@ Verify OODS SoftwareVersions
 Verify OODS SoftwareVersions timing
     [Tags]    software_versions    timing
     Set Tags    ${OODS}
-    Verify Time Delta    ${OODS}    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ${OODS}    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify OODS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -90,7 +90,7 @@ Verify HeaderService SoftwareVersions
 Verify HeaderService SoftwareVersions Event timing
     [Tags]    software_versions    timing
     Set Tags    ${HeaderService}
-    Verify Time Delta    ${HeaderService}    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ${HeaderService}    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #OCPS:2||3
 Verify OCPS:2||3 Standby
@@ -106,7 +106,7 @@ Verify OCPS:2||3 SoftwareVersions
 Verify OCPS:2||3 SoftwareVersions Event timing
     [Tags]    software_versions    timing
     Set Tags    OCPS:${OcpsIndex}
-    Verify Time Delta    OCPS    logevent_softwareVersions    logevent_summaryState    index=${OcpsIndex}
+    Verify Time Delta    OCPS:${OcpsIndex}    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify OCPS:2||3 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -116,4 +116,4 @@ Verify OCPS:2||3 ConfigurationsAvailable Event
 Verify OCPS:2||3 ConfigurationsAvailable Event timing
     [Tags]    config_available    timing
     Set Tags    OCPS:${OcpsIndex}
-    Verify Time Delta    OCPS    logevent_configurationsAvailable    logevent_summaryState    index=${OcpsIndex}
+    Verify Time Delta    OCPS:${OcpsIndex}    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Standby/Verify_EAS_AE_Standby.robot
+++ b/Standby/Verify_EAS_AE_Standby.robot
@@ -24,7 +24,7 @@ Verify DSM:1 SoftwareVersions
 
 Verify DSM:1 SoftwareVersions timing
     [Tags]    eas_ae    software_versions    timing
-    Verify Time Delta    DSM    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    DSM:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DSM:1 ConfigurationsAvailable Event
     [Tags]    eas_ae    config_available
@@ -41,7 +41,7 @@ Verify DSM:2 SoftwareVersions
 
 Verify DSM:2 SoftwareVersions timing
     [Tags]    eas_ae    software_versions    timing
-    Verify Time Delta    DSM    logevent_softwareVersions    logevent_summaryState    index=2
+    Verify Time Delta    DSM:2    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DSM:2 ConfigurationsAvailable Event
     [Tags]    eas_ae    config_available
@@ -58,7 +58,7 @@ Verify WeatherForecast SoftwareVersions
 
 Verify WeatherForecast SoftwareVersions timing
     [Tags]    eas_ae    software_versions    timing
-    Verify Time Delta    WeatherForecast    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    WeatherForecast    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify WeatherForecast ConfigurationsAvailable Event
     [Tags]    eas_ae    config_available

--- a/Standby/Verify_EAS_Standby.robot
+++ b/Standby/Verify_EAS_Standby.robot
@@ -54,7 +54,7 @@ Verify DIMM:1 SoftwareVersions
 
 Verify DIMM:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    DIMM:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DIMM:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -62,7 +62,7 @@ Verify DIMM:1 ConfigurationsAvailable Event
 
 Verify DIMM:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    DIMM    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    DIMM:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # DIMM:2
 Verify DIMM:2 Standby
@@ -75,7 +75,7 @@ Verify DIMM:2 SoftwareVersions
 
 Verify DIMM:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    DIMM    logevent_softwareVersions    logevent_summaryState    index=2
+    Verify Time Delta    DIMM:2    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify DIMM:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -83,7 +83,7 @@ Verify DIMM:2 ConfigurationsAvailable Event
 
 Verify DIMM:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    DIMM    logevent_configurationsAvailable    logevent_summaryState    index=2
+    Verify Time Delta    DIMM:2    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # EPM:1
 Verify EPM:1 Standby
@@ -96,7 +96,7 @@ Verify EPM:1 SoftwareVersions
 
 Verify EPM:1 SoftwareVersions timing
     [Tags]    epm:1    software_versions    timing
-    Verify Time Delta    EPM    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    EPM:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify EPM:1 ConfigurationsAvailable Event
     [Tags]    epm:1    config_available
@@ -104,7 +104,7 @@ Verify EPM:1 ConfigurationsAvailable Event
 
 Verify EPM:1 ConfigurationsAvailable timing
     [Tags]    epm:1    config_available    timing
-    Verify Time Delta    EPM    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    EPM:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:1
 Verify ESS:1 Standby
@@ -117,7 +117,7 @@ Verify ESS:1 SoftwareVersions
 
 Verify ESS:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    ESS:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -125,7 +125,7 @@ Verify ESS:1 ConfigurationsAvailable Event
 
 Verify ESS:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    ESS:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:101
 Verify ESS:101 Standby
@@ -138,7 +138,7 @@ Verify ESS:101 SoftwareVersions
     
 Verify ESS:101 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=101
+    Verify Time Delta    ESS:101    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:101 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -146,7 +146,7 @@ Verify ESS:101 ConfigurationsAvailable Event
 
 Verify ESS:101 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=101
+    Verify Time Delta    ESS:101    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:102
 Verify ESS:102 Standby
@@ -159,7 +159,7 @@ Verify ESS:102 SoftwareVersions
     
 Verify ESS:102 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=102
+    Verify Time Delta    ESS:102    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:102 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -167,7 +167,7 @@ Verify ESS:102 ConfigurationsAvailable Event
 
 Verify ESS:102 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=102
+    Verify Time Delta    ESS:102    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:103
 Verify ESS:103 Standby
@@ -180,7 +180,7 @@ Verify ESS:103 SoftwareVersions
     
 Verify ESS:103 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=103
+    Verify Time Delta    ESS:103    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:103 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -188,7 +188,7 @@ Verify ESS:103 ConfigurationsAvailable Event
 
 Verify ESS:103 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=103
+    Verify Time Delta    ESS:103    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:104
 Verify ESS:104 Standby
@@ -201,7 +201,7 @@ Verify ESS:104 SoftwareVersions
     
 Verify ESS:104 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=104
+    Verify Time Delta    ESS:104    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:104 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -209,7 +209,7 @@ Verify ESS:104 ConfigurationsAvailable Event
 
 Verify ESS:104 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=104
+    Verify Time Delta    ESS:104    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:105
 Verify ESS:105 Standby
@@ -222,7 +222,7 @@ Verify ESS:105 SoftwareVersions
     
 Verify ESS:105 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=105
+    Verify Time Delta    ESS:105    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
     
 Verify ESS:105 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -230,7 +230,7 @@ Verify ESS:105 ConfigurationsAvailable Event
     
 Verify ESS:105 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=105
+    Verify Time Delta    ESS:105    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:106
 Verify ESS:106 Standby
@@ -243,7 +243,7 @@ Verify ESS:106 SoftwareVersions
     
 Verify ESS:106 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=106
+    Verify Time Delta    ESS:106    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
    
 Verify ESS:106 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -251,7 +251,7 @@ Verify ESS:106 ConfigurationsAvailable Event
    
 Verify ESS:106 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=106
+    Verify Time Delta    ESS:106    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:107
 Verify ESS:107 Standby
@@ -264,7 +264,7 @@ Verify ESS:107 SoftwareVersions
     
 Verify ESS:107 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=107
+    Verify Time Delta    ESS:107    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
    
 Verify ESS:107 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -272,7 +272,7 @@ Verify ESS:107 ConfigurationsAvailable Event
    
 Verify ESS:107 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=107
+    Verify Time Delta    ESS:107    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:108
 Verify ESS:108 Standby
@@ -285,7 +285,7 @@ Verify ESS:108 SoftwareVersions
     
 Verify ESS:108 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=108
+    Verify Time Delta    ESS:108    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
    
 Verify ESS:108 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -293,7 +293,7 @@ Verify ESS:108 ConfigurationsAvailable Event
    
 Verify ESS:108 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=108
+    Verify Time Delta    ESS:108    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:201
 Verify ESS:201 Standby
@@ -305,7 +305,7 @@ Verify ESS:201 Standby
 
 Verify ESS:201 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=201
+    Verify Time Delta    ESS:201    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:201 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -313,7 +313,7 @@ Verify ESS:201 ConfigurationsAvailable Event
 
 Verify ESS:201 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=201
+    Verify Time Delta    ESS:201    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:202
 Verify ESS:202 Standby
@@ -326,7 +326,7 @@ Verify ESS:202 SoftwareVersions
 
 Verify ESS:202 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=202
+    Verify Time Delta    ESS:202    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:202 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -334,7 +334,7 @@ Verify ESS:202 ConfigurationsAvailable Event
 
 Verify ESS:202 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=202
+    Verify Time Delta    ESS:202    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:203
 Verify ESS:203 Standby
@@ -347,7 +347,7 @@ Verify ESS:203 SoftwareVersions
 
 Verify ESS:203 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=203
+    Verify Time Delta    ESS:203    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:203 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -355,7 +355,7 @@ Verify ESS:203 ConfigurationsAvailable Event
 
 Verify ESS:203 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=203
+    Verify Time Delta    ESS:203    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:204
 Verify ESS:204 Standby
@@ -368,7 +368,7 @@ Verify ESS:204 SoftwareVersions
 
 Verify ESS:204 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=204
+    Verify Time Delta    ESS:204    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:204 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -376,7 +376,7 @@ Verify ESS:204 ConfigurationsAvailable Event
 
 Verify ESS:204 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=204
+    Verify Time Delta    ESS:204    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:205
 Verify ESS:205 Standby
@@ -389,7 +389,7 @@ Verify ESS:205 SoftwareVersions
 
 Verify ESS:205 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=205
+    Verify Time Delta    ESS:205    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:205 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -397,7 +397,7 @@ Verify ESS:205 ConfigurationsAvailable Event
 
 Verify ESS:205 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=205
+    Verify Time Delta    ESS:205    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # ESS:301
 Verify ESS:301 Standby
@@ -410,7 +410,7 @@ Verify ESS:301 SoftwareVersions
 
 Verify ESS:301 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ESS    logevent_softwareVersions    logevent_summaryState    index=301
+    Verify Time Delta    ESS:301    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ESS:301 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -418,4 +418,4 @@ Verify ESS:301 ConfigurationsAvailable Event
 
 Verify ESS:301 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ESS    logevent_configurationsAvailable    logevent_summaryState    index=301
+    Verify Time Delta    ESS:301    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Standby/Verify_GC_Standby.robot
+++ b/Standby/Verify_GC_Standby.robot
@@ -22,7 +22,7 @@ Verify GenericCamera:1 SoftwareVersions
 
 Verify GenericCamera:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    GenericCamera    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    GenericCamera:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify GenericCamera:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -30,7 +30,7 @@ Verify GenericCamera:1 ConfigurationsAvailable Event
 
 Verify GenericCamera:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    GenericCamera    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    GenericCamera:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # GCHeaderService
 Verify GCHeaderService:1 Standby
@@ -43,7 +43,7 @@ Verify GCHeaderService:1 SoftwareVersions
 
 Verify GCHeaderService:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    GCHeaderService    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    GCHeaderService:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify GCHeaderService:1 ConfigurationsAvailable Event
     [Tags]    config_available

--- a/Standby/Verify_LATISS_Standby.robot
+++ b/Standby/Verify_LATISS_Standby.robot
@@ -28,7 +28,7 @@ Verify ATCamera SoftwareVersions
 
 Verify ATCamera SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATCamera    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATCamera    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATCamera ConfigurationsAvailable Event
     [Tags]    config_available
@@ -36,7 +36,7 @@ Verify ATCamera ConfigurationsAvailable Event
 
 Verify ATCamera ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATCamera    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    ATCamera    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATOODS
 Verify ATOODS Standby
@@ -49,7 +49,7 @@ Verify ATOODS SoftwareVersions
 
 Verify ATOODS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATOODS    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATOODS    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATOODS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -66,7 +66,7 @@ Verify ATHeaderService SoftwareVersions
 
 Verify ATHeaderService SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATHeaderService    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATHeaderService    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATHeaderService ConfigurationsAvailable Event
     [Tags]    config_available
@@ -83,7 +83,7 @@ Verify OCPS:1 SoftwareVersions
 
 Verify OCPS:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    OCPS    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    OCPS:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify OCPS:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -91,7 +91,7 @@ Verify OCPS:1 ConfigurationsAvailable Event
 
 Verify OCPS:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    OCPS    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    OCPS:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #ATSpectrograph
 Verify ATSpectrograph Standby
@@ -104,7 +104,7 @@ Verify ATSpectrograph SoftwareVersions
 
 Verify ATSpectrograph SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    ATSpectrograph    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    ATSpectrograph    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify ATSpectrograph ConfigurationsAvailable Event
     [Tags]    config_available
@@ -112,4 +112,4 @@ Verify ATSpectrograph ConfigurationsAvailable Event
 
 Verify ATSpectrograph ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    ATSpectrograph    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    ATSpectrograph    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}

--- a/Standby/Verify_MTCS_Standby.robot
+++ b/Standby/Verify_MTCS_Standby.robot
@@ -46,7 +46,7 @@ Verify LaserTracker:1 SoftwareVersions
 
 Verify LaserTracker:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    LaserTracker    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    LaserTracker:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify LaserTracker:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -54,7 +54,7 @@ Verify LaserTracker:1 ConfigurationsAvailable Event
 
 Verify LaserTracker:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    LaserTracker    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    LaserTracker:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAirCompressor:1
 Verify MTAirCompressor:1 Standby
@@ -67,7 +67,7 @@ Verify MTAirCompressor:1 SoftwareVersions
 
 Verify MTAirCompressor:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAirCompressor    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    MTAirCompressor:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTAirCompressor:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -75,7 +75,7 @@ Verify MTAirCompressor:1 ConfigurationsAvailable Event
 
 Verify MTAirCompressor:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTAirCompressor    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    MTAirCompressor:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTAirCompressor:2
 Verify MTAirCompressor:2 Standby
@@ -88,7 +88,7 @@ Verify MTAirCompressor:2 SoftwareVersions
 
 Verify MTAirCompressor:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAirCompressor    logevent_softwareVersions    logevent_summaryState    index=2
+    Verify Time Delta    MTAirCompressor:2    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTAirCompressor:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -96,7 +96,7 @@ Verify MTAirCompressor:2 ConfigurationsAvailable Event
 
 Verify MTAirCompressor:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTAirCompressor    logevent_configurationsAvailable    logevent_summaryState    index=2
+    Verify Time Delta    MTAirCompressor:2    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTMount
 Verify MTMount Standby
@@ -114,7 +114,7 @@ Verify MTMount SoftwareVersions
 
 Verify MTMount SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTMount    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTMount    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTMount ConfigurationsAvailable Event
     [Tags]    config_available
@@ -122,7 +122,7 @@ Verify MTMount ConfigurationsAvailable Event
 
 Verify MTMount ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTMount    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTMount    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTPtg
 Verify MTPtg Standby
@@ -135,7 +135,7 @@ Verify MTPtg SoftwareVersions
 
 Verify MTPtg SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTPtg    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTPtg    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTPtg ConfigurationsAvailable Event
     [Tags]    config_available
@@ -152,7 +152,7 @@ Verify MTDome SoftwareVersions
 
 Verify MTDome SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTDome    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTDome    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTDome ConfigurationsAvailable Event
     [Tags]    config_available
@@ -160,7 +160,7 @@ Verify MTDome ConfigurationsAvailable Event
 
 Verify MTDome ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTDome    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTDome    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 #MTDomeTrajectory
 Verify MTDomeTrajectory Standby
@@ -173,7 +173,7 @@ Verify MTDomeTrajectory SoftwareVersions
 
 Verify MTDomeTrajectory SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTDomeTrajectory    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTDomeTrajectory    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTDomeTrajectory ConfigurationsAvailable Event
     [Tags]    config_available
@@ -181,7 +181,7 @@ Verify MTDomeTrajectory ConfigurationsAvailable Event
 
 Verify MTDomeTrajectory ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTDomeTrajectory    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTDomeTrajectory    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTAOS
 Verify MTAOS Standby
@@ -194,7 +194,7 @@ Verify MTAOS SoftwareVersions
 
 Verify MTAOS SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTAOS    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTAOS    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTAOS ConfigurationsAvailable Event
     [Tags]    config_available
@@ -202,7 +202,7 @@ Verify MTAOS ConfigurationsAvailable Event
 
 Verify MTAOS ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTAOS    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTAOS    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTHexapod:1
 Verify MTHexapod:1 Standby
@@ -215,7 +215,7 @@ Verify MTHexapod:1 SoftwareVersions
 
 Verify MTHexapod:1 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTHexapod    logevent_softwareVersions    logevent_summaryState    index=1
+    Verify Time Delta    MTHexapod:1    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTHexapod:1 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -223,7 +223,7 @@ Verify MTHexapod:1 ConfigurationsAvailable Event
 
 Verify MTHexapod:1 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTHexapod    logevent_configurationsAvailable    logevent_summaryState    index=1
+    Verify Time Delta    MTHexapod:1    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTHexapod:2
 Verify MTHexapod:2 Standby
@@ -236,7 +236,7 @@ Verify MTHexapod:2 SoftwareVersions
 
 Verify MTHexapod:2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTHexapod    logevent_softwareVersions    logevent_summaryState    index=2
+    Verify Time Delta    MTHexapod:2    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTHexapod:2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -244,7 +244,7 @@ Verify MTHexapod:2 ConfigurationsAvailable Event
 
 Verify MTHexapod:2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTHexapod    logevent_configurationsAvailable    logevent_summaryState    index=2
+    Verify Time Delta    MTHexapod:2    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTRotator
 Verify MTRotator Standby
@@ -257,7 +257,7 @@ Verify MTRotator SoftwareVersions
 
 Verify MTRotator SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTRotator    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTRotator    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTRotator ConfigurationsAvailable Event
     [Tags]    config_available
@@ -265,7 +265,7 @@ Verify MTRotator ConfigurationsAvailable Event
 
 Verify MTRotator ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTRotator    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTRotator    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTM1M3
 Verify MTM1M3 Standby
@@ -278,7 +278,7 @@ Verify MTM1M3 SoftwareVersions
 
 Verify MTM1M3 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTM1M3    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTM1M3    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTM1M3 ConfigurationsAvailable Event
     [Tags]    config_available    CAP-872
@@ -286,7 +286,7 @@ Verify MTM1M3 ConfigurationsAvailable Event
 
 Verify MTM1M3 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTM1M3    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTM1M3    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 # MTM2
 Verify MTM2 Standby
@@ -299,7 +299,7 @@ Verify MTM2 SoftwareVersions
 
 Verify MTM2 SoftwareVersions timing
     [Tags]    software_versions    timing
-    Verify Time Delta    MTM2    logevent_softwareVersions    logevent_summaryState
+    Verify Time Delta    MTM2    logevent_softwareVersions    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}
 
 Verify MTM2 ConfigurationsAvailable Event
     [Tags]    config_available
@@ -307,4 +307,4 @@ Verify MTM2 ConfigurationsAvailable Event
 
 Verify MTM2 ConfigurationsAvailable timing
     [Tags]    config_available    timing
-    Verify Time Delta    MTM2    logevent_configurationsAvailable    logevent_summaryState
+    Verify Time Delta    MTM2    logevent_configurationsAvailable    hour=${hours_ago}    day=${days_ago}    week=${weeks_ago}


### PR DESCRIPTION
* Updated all the timing tests in the State transition suites.
* Removed the timing tests from the Shutdown suites; they don't really make sense.