### PR TITLE
Tickets/dm45515: Remove the check if failed functions

### DIFF
--- a/Common_Keywords.resource
+++ b/Common_Keywords.resource
@@ -48,27 +48,6 @@ Verify Scripts Completed Successfully
         END
     END
 
-Report If Failed
-    [Documentation]    This keyword creates or updates the `STATE_FAILED` file that is used in the `Check if Failed` keyword.
-    [Arguments]    ${script_indexes}    ${script_states}    ${csc}
-    # See if the STATE_FAILED file exists. It is stored in the ${EXECDIR}/Reports folder, as that is persistent across ArgoCD Workflows.
-    ${exists}=    Run Process    ls     ${EXECDIR}/Reports/STATE_FAILED
-    # If a script failed, either create or update the STATE_FAILED file accordingly.
-    IF    '10' in ${script_states} or '11' in ${script_states}
-        Run Keyword If    ${exists.rc} != 0    Create File    ${EXECDIR}/Reports/STATE_FAILED    Failure in scripts: ${script_indexes} states: ${script_states}\n
-        Run Keyword IF    ${exists.rc} == 0    Append To File    ${EXECDIR}/Reports/STATE_FAILED    Failure in scripts: ${script_indexes} states: ${script_states}\n
-    END
-
-Check If Failed
-    [Documentation]    This keyword checks if the `STATE_FAILED` file contains the word `Failure`, meaning that some number of CSCs failed
-    ...    the State transitions tests. Since this is the case, the remaining tests are unlikely to succeed, so this stops 
-    ...    any further test execution.
-    # If the STATE_FAILED file exists, get the contents. The file is stored in the ${EXECDIR}/Reports folder, as that is persistent across ArgoCD Workflows.
-    ${exists}=    Run Process    ls     ${EXECDIR}/Reports/STATE_FAILED
-    ${state_failed}=    Run Keyword If    ${exists.rc} == 0    Get File    ${EXECDIR}/Reports/STATE_FAILED
-    # If the STATE_FAILED file contains the word 'Failure' halt any further test execution.
-    Run Keyword If    "Failure" in """${state_failed}"""    Fatal Error    msg="One or more CSCs failed the State transitions."
-
 Check If Script Failed
     [Documentation]    This keyword checks if any of the scripts failed.  The keyword takes the list of `script_states` and checks if any of values
     ...    match those in the `failed_script_states` list defined here in the Common_Keywords.robot library.

--- a/Disabled/Execute_Standby_Disabled.robot
+++ b/Disabled/Execute_Standby_Disabled.robot
@@ -31,7 +31,6 @@ Execute ATCS Standby to Disabled
     FOR    ${csc}    IN    @{ATCS}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute LATISS Standby to Disabled
@@ -41,7 +40,6 @@ Execute LATISS Standby to Disabled
         Run Keyword If    "${csc}" == "ATCamera"    Append To List    ${script_args}    -a Normal
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute BigCamera Standby to Disabled
@@ -52,7 +50,6 @@ Execute BigCamera Standby to Disabled
     FOR    ${csc}    IN    @{bigcamera_cscs}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute Calibration Standby to Disabled
@@ -61,7 +58,6 @@ Execute Calibration Standby to Disabled
     FOR    ${csc}    IN    @{Calibration}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute EnvSys Standby to Disabled
@@ -70,7 +66,6 @@ Execute EnvSys Standby to Disabled
     FOR    ${csc}    IN    @{EnvSys}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute GenCam Standby to Disabled
@@ -79,7 +74,6 @@ Execute GenCam Standby to Disabled
     FOR    ${csc}    IN    @{GenCam}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute MTCS Standby to Disabled
@@ -89,7 +83,6 @@ Execute MTCS Standby to Disabled
         Run Keyword If    "${csc}" == "MTM1M3"    Append To List    ${script_args}    -a Default
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute ObsSys Standby to Disabled
@@ -98,7 +91,6 @@ Execute ObsSys Standby to Disabled
     FOR    ${csc}    IN    @{ObsSys}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute Test:42 Standby to Disabled
@@ -106,4 +98,3 @@ Execute Test:42 Standby to Disabled
     @{script_args}=    Create List    ${state}    1
     ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    Test:42    @{script_args}
     Verify Scripts Completed Successfully    ${scripts}    ${states}
-    Report If Failed    ${scripts}    ${states}    Test:42

--- a/Enabled/Execute_Disabled_Enabled.robot
+++ b/Enabled/Execute_Disabled_Enabled.robot
@@ -31,7 +31,6 @@ Execute ATCS Disabled to Enabled
     FOR    ${csc}    IN    @{ATCS}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute LATISS Disabled to Enabled
@@ -41,7 +40,6 @@ Execute LATISS Disabled to Enabled
         Run Keyword If    "${csc}" == "ATCamera"    Append To List    ${script_args}    -a Normal
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute BigCamera Disabled to Enabled
@@ -52,7 +50,6 @@ Execute BigCamera Disabled to Enabled
     FOR    ${csc}    IN    @{bigcamera_cscs}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute Calibration Disabled to Enabled
@@ -61,7 +58,6 @@ Execute Calibration Disabled to Enabled
     FOR    ${csc}    IN    @{Calibration}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute EnvSys Disabled to Enabled
@@ -70,7 +66,6 @@ Execute EnvSys Disabled to Enabled
     FOR    ${csc}    IN    @{EnvSys}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute GenCam Disabled to Enabled
@@ -79,7 +74,6 @@ Execute GenCam Disabled to Enabled
     FOR    ${csc}    IN    @{GenCam}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute MTCS Disabled to Enabled
@@ -88,7 +82,6 @@ Execute MTCS Disabled to Enabled
     FOR    ${csc}    IN    @{MTCS}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute MTAirCompressors Disabled to Enabled
@@ -97,7 +90,6 @@ Execute MTAirCompressors Disabled to Enabled
     FOR    ${csc}    IN    @{AUTO_DISABLED}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute ObsSys Disabled to Enabled
@@ -106,11 +98,9 @@ Execute ObsSys Disabled to Enabled
     FOR    ${csc}    IN    @{ObsSys}
         ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${csc}    @{script_args}
         Verify Scripts Completed Successfully    ${scripts}    ${states}
-        Report If Failed    ${scripts}    ${states}    ${csc}
     END
 
 Execute Test:42 Disabled to Enabled
     [Tags]    test42
     ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    Test:42    Enabled    1
     Verify Scripts Completed Successfully    ${scripts}    ${states}
-    Report If Failed    ${scripts}    ${states}    Test:42

--- a/Standby/Execute_Offline_Standby.robot
+++ b/Standby/Execute_Offline_Standby.robot
@@ -29,11 +29,9 @@ Execute AuxTel Offline to Standby
     [Tags]    atcamera
     ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ATCamera    ${state}    2
     Verify Scripts Completed Successfully    ${scripts}    ${states}
-    Report If Failed    ${scripts}    ${states}    ATCamera
 
 Execute BigCamera Offline to Standby
     [Tags]
     Set Tags    ${BigCamera}
     ${scripts}    ${states}=    Execute Integration Test    csc_state_transition    ${BigCamera}    ${state}    1
     Verify Scripts Completed Successfully    ${scripts}    ${states}
-    Report If Failed    ${scripts}    ${states}    ${BigCamera}


### PR DESCRIPTION
I left in the "Check if Script Failed" keyword, because that is specific to the running test suite; if a script fails, it's unlikely the following checks would work, so skip them.